### PR TITLE
Revisit the TPP build tree to work both standalone and with IREE

### DIFF
--- a/include/Standalone/CMakeLists.txt
+++ b/include/Standalone/CMakeLists.txt
@@ -2,5 +2,5 @@ add_subdirectory(Dialect)
 
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls -name TppCompiler)
-add_public_tablegen_target(TppCompilerPassIncGen)
+add_public_tablegen_target(TPPCompilerPassIncGen)
 add_mlir_doc(Passes TppCompilerPasses ./ -gen-pass-doc)

--- a/include/Standalone/Dialect/LinalgX/TransformOps/CMakeLists.txt
+++ b/include/Standalone/Dialect/LinalgX/TransformOps/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(LLVM_TARGET_DEFINITIONS LinalgXTransformOps.td)
 mlir_tablegen(LinalgXTransformOps.h.inc -gen-op-decls)
 mlir_tablegen(LinalgXTransformOps.cpp.inc -gen-op-defs)
-add_public_tablegen_target(MLIRLinalgXTransformOpsIncGen)
+add_public_tablegen_target(TPPLinalgXTransformOpsIncGen)
 
 add_mlir_doc(LinalgXTransformOps LinalgXStructuredTransformOps Dialects/ -gen-op-doc)

--- a/lib/Standalone/CMakeLists.txt
+++ b/lib/Standalone/CMakeLists.txt
@@ -1,61 +1,52 @@
-add_mlir_dialect_library(TPPStandalone
-        # Ops and dialects
-        Dialect/Tpp/TppDialect.cpp
-        Dialect/Tpp/TppOps.cpp
-        Dialect/Tpp/TppUtils.cpp
-        Dialect/Mathx/MathxDialect.cpp
-        Dialect/Mathx/MathxOps.cpp
-        Dialect/Stdx/StdxOps.cpp
-        Dialect/Stdx/StdxDialect.cpp
-        Dialect/Xsmm/XsmmOps.cpp
-        Dialect/Xsmm/XsmmDialect.cpp
-        Dialect/Xsmm/XsmmAttr.cpp
-        Dialect/LinalgX/LinalgXOps.cpp
-        Dialect/LinalgX/TransformOps/LinalgXTransformOps.cpp
-        Dialect/LinalgX/LinalgXDialect.cpp
-        Dialect/LinalgX/BufferizableOpInterfaceImpl.cpp
-       
-        # Passes 
-        LinalgMapToTpp.cpp
-        PadSIMDDimMatmul.cpp
-        TppCompiler.cpp
-        VectorizeCopy.cpp
-        PreBufferization.cpp
-        MainClosure.cpp
-        UndoMainClosure.cpp
-        Bufferization.cpp
-        TileConsumerAndFuseProducers.cpp
-        DecomposeConvToMatmulOrBrgemm.cpp
-        ToBlockLayoutAndBack.cpp
-        MapToBatchReduceGEMM.cpp
-        TransformDialectInterpreter.cpp
-        IteratorCollapsing.cpp
+add_subdirectory(Dialect)
 
-        # Utils
-        TransformUtils.cpp
- 
-        # Conversions
-        ConvertTppToVector.cpp  
-        ConvertLinalgToTpp.cpp  
-        ConvertTppToLoops.cpp    
-        ConvertTppToXsmm.cpp    
-        ConvertXsmmToFunc.cpp   
-    
-        ADDITIONAL_HEADER_DIRS
-        ${PROJECT_SOURCE_DIR}/include/Standalone
+add_mlir_library(TPPStandalone       
+  # Passes 
+    LinalgMapToTpp.cpp
+    PadSIMDDimMatmul.cpp
+    TppCompiler.cpp
+    VectorizeCopy.cpp
+    PreBufferization.cpp
+    MainClosure.cpp
+    UndoMainClosure.cpp
+    Bufferization.cpp
+    TileConsumerAndFuseProducers.cpp
+    DecomposeConvToMatmulOrBrgemm.cpp
+    ToBlockLayoutAndBack.cpp
+    MapToBatchReduceGEMM.cpp
+    TransformDialectInterpreter.cpp
+    IteratorCollapsing.cpp
 
-        DEPENDS
-        TppCompilerPassIncGen
-        MLIRXsmmAttrDefIncGen
-        MLIRLinalgXTransformOpsIncGen
+  # Utils
+    TransformUtils.cpp
+
+  # Conversions
+    ConvertTppToVector.cpp  
+    ConvertLinalgToTpp.cpp  
+    ConvertTppToLoops.cpp    
+    ConvertTppToXsmm.cpp    
+    ConvertXsmmToFunc.cpp   
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/Standalone
+
+  DEPENDS
+    TPPCompilerPassIncGen
+    TPPLinalgXTransformOps
 
 	LINK_LIBS PUBLIC
-	MLIRIR
-  MLIRInferTypeOpInterface
-	)
+    TPPLinalgXDialect
+    TPPMathxDialect
+    TPPStdxDialect
+    TPPTppDialect
+    TPPXsmmDialect
+    
+    MLIRIR
+    MLIRInferTypeOpInterface
+)
 
 target_include_directories(TPPStandalone 
   PUBLIC
-  $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
-  $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
 )

--- a/lib/Standalone/Dialect/CMakeLists.txt
+++ b/lib/Standalone/Dialect/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(LinalgX)
+add_subdirectory(Mathx)
+add_subdirectory(Stdx)
+add_subdirectory(Tpp)
+add_subdirectory(Xsmm)

--- a/lib/Standalone/Dialect/LinalgX/CMakeLists.txt
+++ b/lib/Standalone/Dialect/LinalgX/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_subdirectory(TransformOps)
+
+add_mlir_dialect_library(TPPLinalgXDialect
+  # Ops and dialects
+    BufferizableOpInterfaceImpl.cpp
+    LinalgXDialect.cpp
+    LinalgXOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/Standalone
+
+  DEPENDS
+    # add_mlir_dialect macro force-prefixes with MLIR
+    MLIRLinalgXOpsIncGen
+    TPPLinalgXTransformOpsIncGen
+
+  LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRInferTypeOpInterface
+)
+
+target_include_directories(TPPLinalgXDialect
+  PUBLIC
+    $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
+)

--- a/lib/Standalone/Dialect/LinalgX/LinalgXDialect.cpp
+++ b/lib/Standalone/Dialect/LinalgX/LinalgXDialect.cpp
@@ -22,3 +22,5 @@ void LinalgXDialect::initialize() {
 #include "Standalone/Dialect/LinalgX/LinalgXOps.cpp.inc"
       >();
 }
+
+#include "Standalone/Dialect/LinalgX/LinalgXOpsDialect.cpp.inc"

--- a/lib/Standalone/Dialect/LinalgX/TransformOps/CMakeLists.txt
+++ b/lib/Standalone/Dialect/LinalgX/TransformOps/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_mlir_dialect_library(TPPLinalgXTransformOps
+    LinalgXTransformOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/Standalone
+
+  DEPENDS
+    TPPLinalgXTransformOpsIncGen
+
+  LINK_LIBS PUBLIC
+    TPPLinalgXDialect
+)
+
+target_include_directories(TPPLinalgXTransformOps
+  PUBLIC
+    $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
+)

--- a/lib/Standalone/Dialect/Mathx/CMakeLists.txt
+++ b/lib/Standalone/Dialect/Mathx/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+add_mlir_dialect_library(TPPMathxDialect
+  # Ops and dialects
+    MathxDialect.cpp
+    MathxOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/Standalone
+
+  DEPENDS
+    # add_mlir_dialect macro force-prefixes with MLIR
+    MLIRMathxOpsIncGen
+
+  LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRInferTypeOpInterface
+)
+
+target_include_directories(TPPMathxDialect
+  PUBLIC
+    $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
+)

--- a/lib/Standalone/Dialect/Mathx/MathxDialect.cpp
+++ b/lib/Standalone/Dialect/Mathx/MathxDialect.cpp
@@ -22,3 +22,5 @@ void MathxDialect::initialize() {
 #include "Standalone/Dialect/Mathx/MathxOps.cpp.inc"
       >();
 }
+
+#include "Standalone/Dialect/Mathx/MathxOpsDialect.cpp.inc"

--- a/lib/Standalone/Dialect/Stdx/CMakeLists.txt
+++ b/lib/Standalone/Dialect/Stdx/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_mlir_dialect_library(TPPStdxDialect
+  # Ops and dialects
+    StdxDialect.cpp
+    StdxOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/Standalone
+
+  DEPENDS
+    # add_mlir_dialect macro force-prefixes with MLIR
+    MLIRStdxOpsIncGen
+
+  LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRInferTypeOpInterface
+)
+
+target_include_directories(TPPStdxDialect
+  PUBLIC
+    $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
+)

--- a/lib/Standalone/Dialect/Stdx/StdxDialect.cpp
+++ b/lib/Standalone/Dialect/Stdx/StdxDialect.cpp
@@ -22,3 +22,5 @@ void StdxDialect::initialize() {
 #include "Standalone/Dialect/Stdx/StdxOps.cpp.inc"
       >();
 }
+
+#include "Standalone/Dialect/Stdx/StdxOpsDialect.cpp.inc"

--- a/lib/Standalone/Dialect/Tpp/CMakeLists.txt
+++ b/lib/Standalone/Dialect/Tpp/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_mlir_dialect_library(TPPTppDialect
+  # Ops and dialects
+    TppDialect.cpp
+    TppOps.cpp
+    TppUtils.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/Standalone
+
+  DEPENDS
+    # add_mlir_dialect macro force-prefixes with MLIR
+    MLIRTppOpsIncGen
+
+  LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRInferTypeOpInterface
+)
+
+target_include_directories(TPPTppDialect
+  PUBLIC
+  $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
+  $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
+)

--- a/lib/Standalone/Dialect/Tpp/TppDialect.cpp
+++ b/lib/Standalone/Dialect/Tpp/TppDialect.cpp
@@ -22,3 +22,5 @@ void TppDialect::initialize() {
 #include "Standalone/Dialect/Tpp/TppOps.cpp.inc"
       >();
 }
+
+#include "Standalone/Dialect/Tpp/TppOpsDialect.cpp.inc"

--- a/lib/Standalone/Dialect/Xsmm/CMakeLists.txt
+++ b/lib/Standalone/Dialect/Xsmm/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_mlir_dialect_library(TPPXsmmDialect
+  # Ops and dialects
+    XsmmAttr.cpp
+    XsmmDialect.cpp
+    XsmmOps.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include/Standalone
+
+  DEPENDS
+    # add_mlir_dialect macro force-prefixes with MLIR
+    MLIRXsmmAttrDefIncGen
+    MLIRXsmmOpsIncGen
+
+  LINK_LIBS PUBLIC
+    MLIRIR
+    MLIRInferTypeOpInterface
+)
+
+target_include_directories(TPPXsmmDialect
+  PUBLIC
+    $<BUILD_INTERFACE:${TPP_GEN_INCLUDE_DIR}>
+    $<BUILD_INTERFACE:${TPP_MAIN_INCLUDE_DIR}>
+)

--- a/lib/Standalone/Dialect/Xsmm/XsmmDialect.cpp
+++ b/lib/Standalone/Dialect/Xsmm/XsmmDialect.cpp
@@ -22,3 +22,5 @@ void XsmmDialect::initialize() {
 #include "Standalone/Dialect/Xsmm/XsmmOps.cpp.inc"
       >();
 }
+
+#include "Standalone/Dialect/Xsmm/XsmmOpsDialect.cpp.inc"

--- a/standalone-opt/standalone-opt.cpp
+++ b/standalone-opt/standalone-opt.cpp
@@ -21,16 +21,11 @@
 
 #include "Standalone/Dialect/LinalgX/BufferizableOpInterfaceImpl.h"
 #include "Standalone/Dialect/LinalgX/LinalgXDialect.h"
-#include "Standalone/Dialect/LinalgX/LinalgXOpsDialect.cpp.inc"
 #include "Standalone/Dialect/LinalgX/TransformOps/LinalgXTransformOps.h"
 #include "Standalone/Dialect/Mathx/MathxDialect.h"
-#include "Standalone/Dialect/Mathx/MathxOpsDialect.cpp.inc"
 #include "Standalone/Dialect/Stdx/StdxDialect.h"
-#include "Standalone/Dialect/Stdx/StdxOpsDialect.cpp.inc"
 #include "Standalone/Dialect/Tpp/TppDialect.h"
-#include "Standalone/Dialect/Tpp/TppOpsDialect.cpp.inc"
 #include "Standalone/Dialect/Xsmm/XsmmDialect.h"
-#include "Standalone/Dialect/Xsmm/XsmmOpsDialect.cpp.inc"
 #include "Standalone/Passes.h"
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This revision refactors the cmake build tree to be more in line with upstream best practices.
A few issues surfaced when trying to integrate this deeply with IREE.

Local testing with both IREE and standalone TPP is successful with these changes.