### PR TITLE
3 dimensional input for packed bf16

### DIFF
--- a/include/Standalone/Dialect/Tpp/TppOps.td
+++ b/include/Standalone/Dialect/Tpp/TppOps.td
@@ -23,10 +23,13 @@ class StaticMemRefRankOf<list<Type> allowedTypes, list<int> ranks> :
          "::mlir::MemRefType">;
 
 def TppMemRef : StaticMemRefRankOf<[AnyFloat], [1, 2]>;
+def TppPackedMemrefInput : StaticMemRefRankOf<[AnyFloat], [1, 2, 3]>;
 def TppBRGEMMemrefInput : StaticMemRefRankOf<[AnyFloat], [3]>;
 
 // Tpp operands is a scalar float or a static memref with rank 1 or 2.
 def TppOperand : AnyTypeOf<[TppMemRef, AnyFloat]>;
+
+def TppPackedOperand : AnyTypeOf<[TppPackedMemrefInput, AnyFloat]>;
 
 //===----------------------------------------------------------------------===//
 // AddOp
@@ -132,7 +135,7 @@ def Tpp_MatmulOp : Tpp_Op<"matmul"> {
     ```
   }];
 
-  let arguments = (ins TppOperand:$matrixA, TppOperand:$matrixB, 
+  let arguments = (ins TppPackedOperand:$matrixA, TppOperand:$matrixB, 
                        TppOperand:$matrixC);
 
   let assemblyFormat = [{

--- a/lib/Standalone/ConvertTppToLoops.cpp
+++ b/lib/Standalone/ConvertTppToLoops.cpp
@@ -220,6 +220,8 @@ struct ConvertTppMatmulOp : public OpRewritePattern<MatmulOp> {
     ArrayRef<int64_t> shapeC = matmulOp.getMatrixCType().getShape();
     ArrayRef<int64_t> shapeA =
         matmulOp.getMatrixA().getType().cast<MemRefType>().getShape();
+    if (shapeA.size() == 3)
+      matmulOp.emitError("Packed BF16 loops unsupported");
     Value i = rewriter.create<arith::ConstantIndexOp>(loc, shapeC[0]);
     Value j = rewriter.create<arith::ConstantIndexOp>(loc, shapeC[1]);
     Value k = rewriter.create<arith::ConstantIndexOp>(loc, shapeA[1]);

--- a/lib/Standalone/ConvertTppToXsmm.cpp
+++ b/lib/Standalone/ConvertTppToXsmm.cpp
@@ -52,6 +52,12 @@ struct ConvertTppMatmulOp : public OpRewritePattern<MatmulOp> {
     if (failed(ldaDim))
       return failure();
     int64_t lda = *ldaDim;
+    if (memrefA.getElementType().isBF16() && memrefA.getShape().size() == 3) {
+      auto divLdaDim = getLeadingDim(memrefA, 1);
+      if (failed(divLdaDim))
+        return failure();
+      lda = lda / (*divLdaDim);
+    }
 
     auto ldbDim = getLeadingDim(memrefB);
     if (failed(ldbDim))

--- a/lib/Standalone/Dialect/Tpp/TppOps.cpp
+++ b/lib/Standalone/Dialect/Tpp/TppOps.cpp
@@ -56,14 +56,17 @@ LogicalResult MatmulOp::verify() {
   MemRefType a = getMatrixA().getType().cast<MemRefType>();
   MemRefType b = getMatrixB().getType().cast<MemRefType>();
   MemRefType c = getMatrixC().getType().cast<MemRefType>();
-  if ((a.getShape().size() != 2) || (b.getShape().size() != 2) ||
-      (c.getShape().size() != 2))
-    return failure();
+  if ((a.getShape().size() != 2 && !a.getElementType().isBF16()) ||
+      (a.getElementType().isBF16() && a.getShape().size() != 3 &&
+       a.getShape().size() != 2) ||
+      (b.getShape().size() != 2) || (c.getShape().size() != 2))
+    return emitError("shapes incompatible");
   int64_t m = c.getShape()[0];
   int64_t n = c.getShape()[1];
   int64_t k = a.getShape()[1];
-  if ((a.getShape()[0] != m) || (b.getShape()[1] != n) ||
-      (b.getShape()[0] != k))
-    return failure();
+  if ((a.getShape().size() == 2 && a.getShape()[0] != m) ||
+      (a.getShape().size() == 3 && a.getShape()[0] * a.getShape()[2] != m) ||
+      (b.getShape()[1] != n) || (b.getShape()[0] != k))
+    return emitError("Dimensions mismatching");
   return success();
 }

--- a/test/Integration/matmul-pbf16.mlir
+++ b/test/Integration/matmul-pbf16.mlir
@@ -1,0 +1,49 @@
+// UNSUPPORTED: !x86_64
+
+// RUN: standalone-opt %s -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -sparse-compiler|\
+// RUN: mlir-cpu-runner \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%standalonelibdir/libstandalone_c_runner_utils%shlibext | \
+// RUN: FileCheck %s
+//
+
+#map3 = affine_map<(d0, d1, d2) -> (d0 * 2 + d2, d1)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+module {
+ func.func @matmultpp(%A: memref<2x8x2xbf16>, 
+          %B: memref<8x4xbf16>, %C: memref<4x4xbf16>) attributes {llvm.emit_c_interface} {
+    tpp.matmul ins(%A: memref<2x8x2xbf16>, %B: memref<8x4xbf16>)
+             out(%C: memref<4x4xbf16>)
+    return
+  }
+
+  func.func @entry() {
+    %c0 = arith.constant 0 : index
+    %f0 = arith.constant 1.0 : bf16
+    %da = memref.alloc() :memref<4x8xbf16>
+    linalg.fill ins(%f0 : bf16) outs(%da : memref<4x8xbf16>)
+    %db = memref.alloc() :memref<8x4xbf16>
+    linalg.fill ins(%f0:bf16) outs (%db:memref<8x4xbf16>)
+    // Call kernel.
+    %0 = memref.alloc() : memref<2x8x2xbf16>
+    linalgx.relayout ins(%da: memref<4x8xbf16>, #map3) outs(%0: memref<2x8x2xbf16>, #map4)
+    
+    %D = memref.alloc() : memref<4x4xbf16>
+    %zero = arith.constant 0.0 : bf16
+    linalg.fill ins(%zero : bf16) outs(%D:memref<4x4xbf16>)
+    call @matmultpp(%0, %db, %D)
+       : (memref<2x8x2xbf16>, memref<8x4xbf16>, memref<4x4xbf16>)->()
+
+    //
+    // CHECK:( ( 8, 8, 8, 8 ), ( 8, 8, 8, 8 ), ( 8, 8, 8, 8 ), ( 8, 8, 8, 8 ) )
+    //
+    %d1 = arith.constant -1.0 : bf16
+
+    %v0 = vector.transfer_read %D[%c0, %c0], %d1 : memref<4x4xbf16>, vector<4x4xbf16>
+    %f1 = arith.extf %v0:vector<4x4xbf16> to vector<4x4xf32>
+    vector.print %f1 : vector<4x4xf32>
+
+    return
+  }
+ 
+}

--- a/test/Standalone/tpp-to-loops-invalid.mlir
+++ b/test/Standalone/tpp-to-loops-invalid.mlir
@@ -1,0 +1,12 @@
+// UNSUPPORTED: !x86_64
+
+// RUN: standalone-opt %s -convert-tpp-to-loops -verify-diagnostics
+
+func.func @matmul_to_loops(%arg0: memref<2x8x2xbf16>, %arg1: memref<8x4xbf16>, %arg2: memref<4x4xbf16>) {
+ // expected-error @below {{Packed BF16 loops unsupported}}
+ // expected-error @below {{'memref.load' op incorrect number of indices for load}}
+  tpp.matmul ins(%arg0: memref<2x8x2xbf16>, %arg1: memref<8x4xbf16>)
+             out(%arg2: memref<4x4xbf16>)
+  return
+}
+


### PR DESCRIPTION
Even round-trippability seems broken with this, I see no errors or outputs on running standalone-opt on the committed mlir file.