### PR TITLE
Use more descriptive name in `MapConvToMatmulOp` (NFC)

### DIFF
--- a/include/Standalone/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
+++ b/include/Standalone/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
@@ -112,11 +112,14 @@ def MapConvToMatmulOp : Op<Transform_Dialect,
   }];
 
   let arguments = (ins PDL_Operation:$target,
-                       ConfinedAttr<I64Attr, [IntNonNegative]>:$rPos,
-                       ConfinedAttr<I64Attr, [IntNonNegative]>:$sPos);
+                       ConfinedAttr<I64Attr, [IntNonNegative]>:$filter_height_pos,
+                       ConfinedAttr<I64Attr, [IntNonNegative]>:$filter_width_pos);
   let results = (outs PDL_Operation:$maybe_linalg_batch_reduce_op);
 
-  let assemblyFormat = "$target `(` `rPos` `=` $rPos `,` `sPos` `=` $sPos `)` attr-dict";
+  let assemblyFormat = [{
+    $target `(` `filter_height_pos` `=` $filter_height_pos 
+                `,` `filter_width_pos` `=` $filter_width_pos `)` attr-dict
+  }];
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(

--- a/lib/Standalone/Dialect/LinalgX/TransformOps/LinalgXTransformOps.cpp
+++ b/lib/Standalone/Dialect/LinalgX/TransformOps/LinalgXTransformOps.cpp
@@ -149,8 +149,9 @@ transform::MapConvToMatmulOp::applyToOne(linalg::LinalgOp target,
     return DiagnosedSilenceableFailure::definiteFailure();
   SimpleRewriter rewriter(target->getContext());
   rewriter.setInsertionPoint(target);
-  FailureOr<linalg::MatmulOp> matmul = mlir::linalgx::mapConvToGemm(
-      rewriter, cast<linalg::GenericOp>(target), getRPos(), getSPos());
+  FailureOr<linalg::MatmulOp> matmul =
+      mlir::linalgx::mapConvToGemm(rewriter, cast<linalg::GenericOp>(target),
+                                   getFilterHeightPos(), getFilterWidthPos());
   if (failed(matmul))
     return DiagnosedSilenceableFailure::definiteFailure();
   results.push_back(*matmul);

--- a/test/Standalone/transform-conv.mlir
+++ b/test/Standalone/transform-conv.mlir
@@ -7,7 +7,7 @@ transform.with_pdl_patterns {
       %0 = transform.structured.match ops{["linalg.conv_2d_nhwc_hwcf"]} in %arg1
       %1 = transform.structured.generalize %0
       %2 = transform.structured.interchange %1 { iterator_interchange = [0, 1, 4, 5, 2, 3, 6] }
-      %3 = transform.structured.map_conv_to_matmul %2 (rPos = 0, sPos = 1)
+      %3 = transform.structured.map_conv_to_matmul %2 (filter_height_pos = 0, filter_width_pos = 1)
   }
 }
 


### PR DESCRIPTION
filter_height_pos, and filter_width_pos represent the filter height and weight index, respectively. If the filter height and width are not one, we need to consider a sliding window when mapping to matmul; thus, we need the position of the height and width in the filter.