### PR TITLE
Create TPP-RUN program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ add_subdirectory(tpp-rt)
 # IREE doesn't need any of these
 if (NOT TPP_INSIDE_IREE)
   add_subdirectory(tpp-opt)
+  add_subdirectory(tpp-run)
   add_subdirectory(test)
 endif()
 

--- a/test/BF16/matmul-bf16.mlir
+++ b/test/BF16/matmul-bf16.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf | \
-// RUN: tpp-run \
+// RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/BF16/matmul-bf16.mlir
+++ b/test/BF16/matmul-bf16.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/BF16/matmul-bf16.mlir
+++ b/test/BF16/matmul-bf16.mlir
@@ -1,5 +1,5 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/BF16/matmul-pbf16.mlir
+++ b/test/BF16/matmul-pbf16.mlir
@@ -1,5 +1,5 @@
-// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -sparse-compiler|\
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/BF16/matmul-pbf16.mlir
+++ b/test/BF16/matmul-pbf16.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
-// RUN: tpp-run \
+// RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/BF16/mlp-all-bf16.mlir
+++ b/test/BF16/mlp-all-bf16.mlir
@@ -1,5 +1,5 @@
-// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -sparse-compiler|\
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext
 //

--- a/test/BF16/mlp-all-bf16.mlir
+++ b/test/BF16/mlp-all-bf16.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
-// RUN: tpp-run \
+// RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext
 //

--- a/test/BF16/mlp-single-layer-bf16.mlir
+++ b/test/BF16/mlp-single-layer-bf16.mlir
@@ -1,5 +1,5 @@
-// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -sparse-compiler|\
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext
 //

--- a/test/BF16/mlp-single-layer-bf16.mlir
+++ b/test/BF16/mlp-single-layer-bf16.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
-// RUN: tpp-run \
+// RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext
 //

--- a/test/BF16/mlp-single-layer-blocked-bf16.mlir
+++ b/test/BF16/mlp-single-layer-blocked-bf16.mlir
@@ -1,5 +1,5 @@
 // RUN:tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
-// RUN: tpp-run \
+// RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/BF16/mlp-single-layer-blocked-bf16.mlir
+++ b/test/BF16/mlp-single-layer-blocked-bf16.mlir
@@ -1,5 +1,5 @@
-// RUN:tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -sparse-compiler |\
-// RUN: mlir-cpu-runner \
+// RUN:tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,7 @@ configure_lit_site_cfg(
 set(TPP_OPT_TEST_DEPENDS
         FileCheck count not
         tpp-opt
+        tpp-run
         TPPUnitTests
         )
 

--- a/test/Integration/brgemm-tpp.mlir
+++ b/test/Integration/brgemm-tpp.mlir
@@ -1,12 +1,12 @@
-// RUN: tpp-opt %s -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/conv-mapping-to-gemm.mlir
+++ b/test/Integration/conv-mapping-to-gemm.mlir
@@ -1,11 +1,11 @@
-// RUN: tpp-opt %s -decompose-conv-to-matmul-or-brgemm -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -sparse-compiler -reconcile-unrealized-casts | \
+// RUN: tpp-opt %s -decompose-conv-to-matmul-or-brgemm -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler | \
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -sparse-compiler -reconcile-unrealized-casts | \
+// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler | \
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \

--- a/test/Integration/copy.mlir
+++ b/test/Integration/copy.mlir
@@ -1,19 +1,19 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp -pad-simd-dim-for-matmul -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pad-simd-dim-for-matmul -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/matmul-one-shot-buff.mlir
+++ b/test/Integration/matmul-one-shot-buff.mlir
@@ -1,5 +1,5 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/matmul-tpp-with-print.mlir
+++ b/test/Integration/matmul-tpp-with-print.mlir
@@ -1,5 +1,5 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp -convert-linalg-to-tpp -convert-linalg-to-loops -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -convert-linalg-to-tpp -convert-linalg-to-loops -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%llvmlirdir/libmlir_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/matmul-tpp.mlir
+++ b/test/Integration/matmul-tpp.mlir
@@ -1,19 +1,19 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp -pad-simd-dim-for-matmul -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pad-simd-dim-for-matmul -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/non-unit-batch-brgemm-tpp.mlir
+++ b/test/Integration/non-unit-batch-brgemm-tpp.mlir
@@ -1,12 +1,12 @@
-// RUN: tpp-opt %s -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/relu.mlir
+++ b/test/Integration/relu.mlir
@@ -1,12 +1,12 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/simple-copy.mlir
+++ b/test/Integration/simple-copy.mlir
@@ -1,19 +1,19 @@
-// RUN: tpp-opt %s -map-linalg-to-tpp -pad-simd-dim-for-matmul -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pad-simd-dim-for-matmul -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/smoke.mlir
+++ b/test/Integration/smoke.mlir
@@ -4,10 +4,8 @@
 // RUN:   --linalg-bufferize --convert-linalg-to-loops \
 // RUN:   --convert-vector-to-scf --convert-scf-to-cf \
 // RUN:   --func-bufferize --arith-bufferize --tensor-bufferize \
-// RUN:   --finalizing-bufferize --lower-affine \
-// RUN:   --convert-vector-to-llvm --convert-memref-to-llvm \
-// RUN:   --convert-func-to-llvm --reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN:   --finalizing-bufferize --lower-affine | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/tiling-add.mlir
+++ b/test/Integration/tiling-add.mlir
@@ -1,30 +1,30 @@
 // Loop conversion
-// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
 // XSMM conversion
-// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
 // Tiling + loop conversion
-// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp="tile-sizes=8,8" -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp="tile-sizes=8,8" -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
 // Tiling + XSMM conversion
-// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp="tile-sizes=8,8" -convert-tpp-to-xsmm -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp="tile-sizes=8,8" -convert-tpp-to-xsmm -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Integration/tiling-relu.mlir
+++ b/test/Integration/tiling-relu.mlir
@@ -1,30 +1,30 @@
 // Loop conversion
-// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
 // XSMM conversion
-// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
 // Loop conversion
-// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp="tile-sizes=8,8" -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp="tile-sizes=8,8" -convert-tpp-to-loops -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
 // XSMM conversion
-// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp="tile-sizes=8,8" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -reconcile-unrealized-casts | \
-// RUN: mlir-cpu-runner \
+// RUN: tpp-opt %s -map-linalg-to-tpp -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-tpp="tile-sizes=8,8" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func -arith-expand -convert-vector-to-scf -convert-scf-to-cf | \
+// RUN: tpp-run \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -53,7 +53,8 @@ llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 
 tool_dirs = [config.tpp_tools_dir, config.llvm_tools_dir]
 tools = [
-    'tpp-opt'
+    'tpp-opt',
+    'tpp-run'
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)

--- a/tpp-run/CMakeLists.txt
+++ b/tpp-run/CMakeLists.txt
@@ -1,0 +1,34 @@
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+set(LIBS
+        ${dialect_libs}
+        ${conversion_libs}
+        MLIRAnalysis
+        MLIRExecutionEngine
+        MLIRIR
+        MLIRJitRunner
+        MLIRLLVMDialect
+        MLIRLLVMToLLVMIRTranslation
+        MLIRToLLVMIRTranslationRegistration
+        MLIRParser
+        MLIRTargetLLVMIRExport
+        MLIRSupport
+        MLIROptLib
+        MLIRTPP
+        tpp_c_runner_utils
+        )
+
+set(LLVM_LINK_COMPONENTS
+  Core
+  Support
+  nativecodegen
+  native
+  )
+
+add_llvm_executable(tpp-run tpp-run.cpp)
+
+llvm_update_compile_flags(tpp-run)
+
+target_link_libraries(tpp-run PRIVATE ${LIBS})
+
+install(TARGETS tpp-run)

--- a/tpp-run/README.md
+++ b/tpp-run/README.md
@@ -1,0 +1,37 @@
+# TPP Runner
+
+This is basically a copy of `mlir-cpu-runner`, using `JitRunnerMain` and its call backs.
+
+The main difference is that we add a wrapper function to call the kernel (entry) function to allow for benchmarking.
+
+However, we'll need to add:
+ * Random initialization of input tensors (and control the seed, for stable reproduction)
+ * Timing strategy (perhaps with a timer dialect?) to only check kernel times
+ * Repeat functionality, to run just the kernel many times, for statistical significance
+ * Warm-up calls, to allow for JIT compilation to finish before we start timing
+
+We may have to create new callbacks and change LLVM upstream to do that, though.
+
+## Functionality
+
+The main function of this modified TPP runner is to:
+ * (TODO) Automatically find the TPP, LIBXSMM and OpenMP libraries (now is via cmd-line)
+ * Find the kernel function and:
+   * Discover its arguments (input and output)
+   * Allocate memrefs for all and random-initialise the inputs
+ * Compile the kernel MLIR module with `main`, `return` and kernel functions
+ * Run the main function, gathering the outputs (tensors)
+ * Run the kernel function, passing those tensors as arguments
+   * Run multiple times and output statistics in benchmark mode
+ * Run the `return` function to print/cleanup the results
+
+## Implementation
+
+First approach is to use the existing callbacks to wrap our needed functionality:
+ * `mlirTransformer` for parsing the kernel's arguments, preparing the input and calling the kernel, printing the results
+ * `llvmModuleBuilder` for finding the libraries and making sure the IR is correct
+
+We'll probably need a way to measure execution of the kernel, not the tensor preparation and print. 
+This could be done in IR (via `mlirTransformer`) or via some other callback.
+
+If we add new callbacks, we must upstream this.

--- a/tpp-run/README.md
+++ b/tpp-run/README.md
@@ -35,3 +35,15 @@ We'll probably need a way to measure execution of the kernel, not the tensor pre
 This could be done in IR (via `mlirTransformer`) or via some other callback.
 
 If we add new callbacks, we must upstream this.
+
+## Entry Point
+
+Just like `mlir-cpu-runner`, `tpp-run` is supposed to work with `tpp-opt`, `mlir-opt`, etc.
+However, it also introduces MLIR functions, so it has some internal passes to convert those to LLVM, and it requires the original functions *not* to be in the LLVM Dialect.
+
+For these reasons, the entry point of `tpp-run` is _"after all code-gen passes of the optimizer"_ and _"just before the first LLVM lowering"_.
+
+So, if in `mlir-opt` you'd pass LLVM lowering flags to run on `mlir-cpu-runner`, with `tpp-opt`, you cannot.
+All other passes, however, even including partial conversions (ex. `scf-to-cf`) need to be passed, as we can't assume what the original IR had used.
+
+This may change in the future when the program gets more complex, but for now, it's a safe point.

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -1,0 +1,281 @@
+//===- tpp-run.cpp - TPP CPU Execution Driver------------------------------===//
+//
+// Main entry point to a command line utility that executes an MLIR file on the
+// CPU by translating MLIR to LLVM IR before JIT-compiling and executing the
+// latter. Handles TPP/LIBXSMM include/library paths as well as benchmarking
+// modes, with warmups, measurements, output comparison, etc.
+//
+//===----------------------------------------------------------------------===//
+
+#include <iostream>
+
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/InitLLVM.h"
+#include "llvm/Support/TargetSelect.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/ExecutionEngine/JitRunner.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Target/LLVMIR/Dialect/All.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/InitAllPasses.h"
+#include "mlir/Target/LLVMIR/ModuleTranslation.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+
+using namespace mlir;
+
+// This is a hack, to parse the command-line options locally
+// FIXME: Find a way to grab the options from the JitRunner
+struct CmdLineOpts {
+  std::string mainFuncName;
+} options;
+
+static void locaCmdLineOptParsing(int argc, char **argv) {
+  bool nextIsMain = false;
+  for (int i=0; i<argc; i++) {
+    if (strncmp("-e", argv[i], 2) == 0)
+      nextIsMain = true;
+    else if (nextIsMain) {
+      options.mainFuncName = argv[i];
+      break;
+    }
+  }
+}
+
+// Lowers to LLVM Dialect
+static LogicalResult lowerToLLVMDialect(ModuleOp module) {
+  // Minimal passes to make it work
+  // We don't want TPP passes here, as that's the job of tpp-opt
+  // The IR here should be free of TPP/XSMM or any TPP extensions
+  PassManager passManager(module.getContext());
+  applyPassManagerCLOptions(passManager);
+
+  // Bufferization, if needed
+  passManager.addNestedPass<func::FuncOp>(createTensorBufferizePass());
+  passManager.addNestedPass<func::FuncOp>(vector::createVectorBufferizePass());
+  passManager.addNestedPass<func::FuncOp>(createLinalgBufferizePass());
+
+  // Partial Lowering
+  passManager.addPass(createConvertTensorToLinalgPass());
+  passManager.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
+  passManager.addPass(arith::createArithExpandOpsPass());
+  passManager.addPass(createConvertVectorToSCFPass());
+  passManager.addPass(createConvertSCFToCFPass());
+
+  // Lower to LLVM
+  passManager.addPass(createConvertVectorToLLVMPass());
+  passManager.addPass(createConvertFuncToLLVMPass());
+  passManager.addPass(createMemRefToLLVMConversionPass());
+  passManager.addNestedPass<func::FuncOp>(createArithToLLVMConversionPass());
+  passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  passManager.addPass(createReconcileUnrealizedCastsPass());
+
+  auto result = passManager.run(module);
+  if (failed(result)) {
+    std::cerr << "ERROR: Failed to lower module to LLVM dialect" << std::endl;
+    module.dump();
+  }
+
+  return result;
+}
+
+// This function will be called by the pass manager after parsing,
+// so we can modify the IR with the needed wrappers
+static LogicalResult prepareMLIRKernel(Operation *op) {
+  auto module = dyn_cast<ModuleOp>(op);
+  if (!module)
+    return op->emitOpError("expected a 'builtin.module' op");
+
+  // Find the kernel function and its arguments
+  auto moduleRegions = module->getRegions();
+  auto& moduleBlock = moduleRegions.front().front();
+  auto& moduleOps = moduleBlock.getOperations();
+
+  // If the module is already in the LLVM dialect, recomment mlir-cpu-runner
+  for (auto& op: moduleOps) {
+    LLVM::LLVMFuncOp llvmFunc = dyn_cast_or_null<LLVM::LLVMFuncOp>(op);
+    if (llvmFunc)
+      return module.emitError("Module in LLVM Dialect already, use mlir-cpu-runner");
+  }
+
+  // The kernel method
+  func::FuncOp kernel;
+
+  // If the user passed the entry point, use it
+  if (!options.mainFuncName.empty()) {
+    for (auto& op: moduleOps) {
+      func::FuncOp func = dyn_cast_or_null<func::FuncOp>(op);
+      if (!func)
+        continue;
+      if (func.getName().equals(options.mainFuncName)) {
+        kernel = func;
+        break;
+      }
+    }
+    if (!kernel)
+      return module.emitError("Entry point " + options.mainFuncName + " not found");
+
+  // Else, and there is only one function, use it
+  } else if (moduleOps.size() == 1) {
+    kernel = dyn_cast_or_null<func::FuncOp>(moduleOps.front());
+    if (!kernel)
+      return module.emitError("Entry point not in LLVM Dialect");
+    options.mainFuncName = kernel.getName();
+
+  // If there is no entry function, and multiple functions, bail
+  } else {
+    return module.emitError("No valid entry point, use mlir-cpu-runner");
+  }
+
+  // If the function has no args or return values, just run it as is
+  auto funcType = kernel.getFunctionType();
+  if (funcType.getNumInputs() == 0 && funcType.getNumResults() == 0) {
+    module.emitRemark("Entry point already created, just running the IR");
+    return lowerToLLVMDialect(module);
+  }
+
+  // Also ignore functions that return more than one result
+  if (funcType.getNumResults() > 1)
+    return module.emitError("Multiple return values, use mlir-cpu-runner");
+
+  // Gets a builder on the module
+  auto* ctx = module.getContext();
+  ctx->getOrLoadDialect<tensor::TensorDialect>();
+  ctx->getOrLoadDialect<vector::VectorDialect>();
+  OpBuilder builder(ctx);
+  Location loc = builder.getUnknownLoc();
+
+  // Rename the entry point to something else and make the main the entry point
+  // This is required because we can't change the original options.mainFuncName
+  auto name = kernel.getName();
+  auto newName = builder.getStringAttr("_" + name);
+  kernel.setName(newName);
+
+  // Add a `main` function (with no args/rets) to handle init/tear down
+  auto newFuncType = builder.getFunctionType({}, {});
+  auto main = func::FuncOp::create(loc, name, newFuncType);
+  main.setVisibility(SymbolTable::Visibility::Public);
+  auto entryBlock = main.addEntryBlock();
+
+  // Initialise the inputs as global constants
+  // TODO: Use some random initialiser
+  APFloat floatValue = APFloat(1.0F);
+
+  // Create global dense memrefs (module insertion point)
+  builder.setInsertionPointToStart(&moduleBlock);
+  auto privAttr = builder.getStringAttr("private");
+  int order = 0;
+  for (auto& ty: funcType.getInputs()) {
+    // We really only support memrefs as arguments for now
+    auto memrefTy = dyn_cast_or_null<MemRefType>(ty);
+    assert(memrefTy && "Unsupported argument type");
+
+    // Global op properties
+    std::string name = "__wrapper_const_" + std::to_string(order++);
+    auto nameAttr = builder.getStringAttr(name);
+    auto typeAttr = TypeAttr::get(ty);
+    // For some reason, memref global op needs dense tensor type
+    // See: lib/Dialect/MemRef/IR/MemRefOps.cpp :: GlobalOp::verify
+    auto tensorType = RankedTensorType::get(memrefTy.getShape(), memrefTy.getElementType());
+    auto floatInit = mlir::DenseElementsAttr::get(tensorType, floatValue);
+    auto constant = UnitAttr::get(ctx);
+    auto alignment = builder.getIntegerAttr(builder.getI64Type(), 128);
+
+    // Create the global object in the module's region
+    builder.create<memref::GlobalOp>(loc, nameAttr, privAttr, typeAttr, floatInit, constant, alignment);
+  }
+
+  // Get those globals as arguments (function insertion point)
+  builder.setInsertionPointToStart(entryBlock);
+  SmallVector<Value> args;
+  order = 0;
+  for (auto& ty: funcType.getInputs()) {
+    // GetGlobal op properties
+    std::string name = "__wrapper_const_" + std::to_string(order++);
+    auto nameAttr = builder.getStringAttr(name);
+    auto getGlobal = builder.create<memref::GetGlobalOp>(loc, ty, nameAttr);
+
+    // Add argument to list
+    args.push_back(getGlobal);
+  }
+
+  // Call the kernel
+  Value result;
+  if (funcType.getNumResults() == 0) {
+    builder.create<func::CallOp>(loc, kernel, args);
+    result = args.back();
+  } else {
+    auto call = builder.create<func::CallOp>(loc, kernel, args);
+    result = call->getOpResult(0);
+  }
+
+  // Read into a vector and print output
+  APFloat vectorFloatValue = APFloat(-1.0F);
+  auto minusOne = builder.create<arith::ConstantFloatOp>(loc, vectorFloatValue, builder.getF32Type());
+  auto zeroIdx = builder.create<arith::ConstantIndexOp>(loc, 0);
+  auto outputType = dyn_cast_or_null<MemRefType>(result.getType());
+  assert(outputType && "Unsupported return type");
+  auto vecType = VectorType::get(outputType.getShape(), outputType.getElementType());
+  auto indices = ValueRange{zeroIdx, zeroIdx};
+  auto vector = builder.create<vector::TransferReadOp>(loc, vecType, result, indices, minusOne);
+  builder.create<vector::PrintOp>(loc, vector);
+
+  // Return void and add func to module
+  builder.create<func::ReturnOp>(loc);
+  module.push_back(main);
+
+  // Finally lower to LLVM Dialect
+  return lowerToLLVMDialect(module);
+}
+
+// This function will be called at the end, to emit an LLVM Module.
+// It may not be necessary, but here just in case.
+static std::unique_ptr<llvm::Module> buildLLVMModule(Operation *op, llvm::LLVMContext& context) {
+  auto module = dyn_cast<ModuleOp>(op);
+  assert(module && "expected a 'builtin.module' op");
+
+  // Not sure what to do here...
+  // See SPIRV CPU runner as an example
+  // For now, this is just a copy of what the original function does
+  std::unique_ptr<llvm::Module> llvm = translateModuleToLLVMIR(module, context);
+  return llvm;
+}
+
+int main(int argc, char **argv) {
+  // Initialize the LLVM machinery
+  llvm::InitLLVM y(argc, argv);
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  llvm::InitializeNativeTargetAsmParser();
+
+  // Add the following to include *all* MLIR Core dialects, or selectively
+  // include what you need like above. You only need to register dialects that
+  // will be *parsed* by the tool, not the one generated
+  DialectRegistry registry;
+  registerAllDialects(registry);
+  registerAllToLLVMIRTranslations(registry);
+
+  // This is how we integrate with the pipeline
+  JitRunnerConfig config;
+  config.mlirTransformer = prepareMLIRKernel;
+  config.llvmModuleBuilder = buildLLVMModule;
+
+  // Hack
+  locaCmdLineOptParsing(argc, argv);
+
+  // Call the main JIT function
+  return JitRunnerMain(argc, argv, registry, config);
+}

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/TargetSelect.h"
@@ -85,7 +83,7 @@ static LogicalResult lowerToLLVMDialect(ModuleOp module) {
 
   auto result = passManager.run(module);
   if (failed(result)) {
-    std::cerr << "ERROR: Failed to lower module to LLVM dialect" << std::endl;
+    llvm::errs() << "ERROR: Failed to lower module to LLVM dialect\n";
     module.dump();
   }
 


### PR DESCRIPTION
This program is a replacement for mlir-cpu-runner for a small number of cases, where we want to quickly call a MLIR method with a wrapper function that initializes the arguments and prints the output.

In addition, on benchmark mode, we also want to time the execution of the kernel (but not the tensor setup, JIT compile times, etc).

For everything else, you should use mlir-cpu-runner and equivalent.

Tests were amended to use the right tool using the right command line options for tpp-run as well as update options for tpp-opt.

For now, the features available are:
 * Reads MLIR file in `func` dialect (not `LLVM` dialect)
 * Detects / uses entry point passed as argument (or single function)
 * Creates a wrapper function that scans arguments and return values
 * Initializes arguments, prepare return values and calls the function
 * Prints the return value (whether it was returned or inplace)

What's still missing:
 * Expecting IR to be on a particular shape (memref) isn't very robust
 * Initializing arguments with splat(1.0), need to be random
 * Needs random seed to allow for predictable / comparable runs
 * Has no timer functionality yet
 * Doesn't try to figure out libxsmm/tpp library paths automaticaly

Bugs:
 * Inplace returns are still printing the original (arg) value
 * Can't update cmd-line args, needs hack, can't hav additional args

Future changes that may need MLIR (JitRunner) changes:
 * We need to access the cmd-line options
 * We need to time just the kernel execution, not setup, not JIT

Partially Implements #74