### PR TITLE
Make the tpp.add 1 input 1 output

### DIFF
--- a/include/TPP/Dialect/Tpp/TppDialect.td
+++ b/include/TPP/Dialect/Tpp/TppDialect.td
@@ -30,7 +30,7 @@ def Tpp_Dialect : Dialect {
 // Base operation definition.
 //===----------------------------------------------------------------------===//
 
-class Tpp_Op<string mnemonic, list<Trait> traits = []> :
+class Tpp_Op<string mnemonic, list<Trait> traits = [SameOperandsElementType]> :
         Op<Tpp_Dialect, mnemonic, traits>;
 
 #endif // TPP_TPP_DIALECT

--- a/include/TPP/Dialect/Tpp/TppOps.td
+++ b/include/TPP/Dialect/Tpp/TppOps.td
@@ -40,25 +40,29 @@ def Tpp_AddOp : Tpp_Op<"add", [SameTypeOperands]> {
     let summary = "Element-wise addition.";
     let description = [{
         The `tpp.add` operation performs element-wise addition
-        on two-dimensional tensors.
+        on two-dimensional memref.
 
         Example:
 
         ```mlir
  
-        tpp.add ins(%1, %2: memref<2x2xf32>, memref<2x2xf32>) 
-                out(%3: memref<2x2xf32>)
+        tpp.add ins(%1 : memref<2x2xf32>) out(%2: memref<2x2xf32>)
         
         ```
     }];
 
-    let arguments = (ins TppOperand:$lhs, TppOperand:$rhs, 
-                         TppOperand:$output);
+    let arguments = (ins TppOperand:$lhs, TppOperand:$rhs);
 
     let assemblyFormat = [{
-        `ins` `(` $lhs `:` type($lhs) `,` $rhs `:` type($rhs) `)` 
-        `out` `(` $output `:` type($output) `)` attr-dict
+        `ins` `(` $lhs `:` type($lhs) `)` 
+        `out` `(` $rhs `:` type($rhs) `)` attr-dict
     }];
+
+    let extraClassDeclaration = [{
+      Value getOutput() { return getRhs(); };
+    }];
+
+    let hasVerifier = 1;
 }
 
 //===----------------------------------------------------------------------===//
@@ -68,7 +72,7 @@ def Tpp_AddOp : Tpp_Op<"add", [SameTypeOperands]> {
 def Tpp_IdentityOp : Tpp_Op<"identity"> {
   let summary = "Copies input to output.";
   let description = [{
-    The `tpp.identity` copies input to output.
+    The `tpp.identity` copies input memref to output memref.
     
     Example:
 
@@ -208,6 +212,7 @@ def Tpp_BrgemmOp : Tpp_Op<"brgemm"> {
   let builders = [
     OpBuilder<(ins "ValueRange":$inputs, "Value":$output)>
   ];
+  
   let hasVerifier = 1;
 }
 

--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -269,7 +269,7 @@ struct ConvertGenericOpToTpp : public OpRewritePattern<linalg::GenericOp> {
     }
     if (libraryCall.compare("tpp.add") == 0) {
       rewriter.replaceOpWithNewOp<tpp::AddOp>(linalgOp, operands[0],
-                                              operands[1], operands[2]);
+                                              operands[1]);
       return success();
     }
     if (libraryCall.compare("tpp.matmul") == 0) {

--- a/lib/TPP/LinalgMapToTpp.cpp
+++ b/lib/TPP/LinalgMapToTpp.cpp
@@ -75,6 +75,11 @@ struct MapGenericOpToTpp : public OpRewritePattern<linalg::GenericOp> {
     return hasMatmulBody(linalgOp);
   }
 
+  // Return true if the operation as 1 input and 1 output.
+  bool hasOneInputOneOutput(linalg::GenericOp linalgOp) const {
+    return ((linalgOp.getNumInputs() == 1) && (linalgOp.getNumOutputs() == 1));
+  }
+
   LogicalResult matchAndRewrite(linalg::GenericOp linalgOp,
                                 PatternRewriter &rewriter) const override {
     if (!hasStaticShape(linalgOp))
@@ -108,7 +113,7 @@ struct MapGenericOpToTpp : public OpRewritePattern<linalg::GenericOp> {
       return success();
     }
     if (hasOnlyScalarElementwiseOp<arith::AddFOp>(linalgOp.getRegion()) &&
-        hasStaticShape(linalgOp)) {
+        hasStaticShape(linalgOp) && hasOneInputOneOutput(linalgOp)) {
       StringAttr tppMicroKernelName = rewriter.getStringAttr("tpp.add");
       rewriter.updateRootInPlace(
           linalgOp, [&]() { linalgOp.setLibraryCallAttr(tppMicroKernelName); });

--- a/test/Integration/tiling-add.mlir
+++ b/test/Integration/tiling-add.mlir
@@ -35,11 +35,11 @@
 module {
 
   func.func @bigadd(%A: tensor<32x16xf32>,
-                  %B: tensor<32x16xf32>, %C: tensor<32x16xf32>) -> tensor<32x16xf32> attributes {llvm.emit_c_interface} {
-    %O = linalg.generic { indexing_maps = [#map0, #map0, #map0],
+                  %B: tensor<32x16xf32>) -> tensor<32x16xf32> attributes {llvm.emit_c_interface} {
+    %O = linalg.generic { indexing_maps = [#map0, #map0],
                         iterator_types = ["parallel", "parallel"] }
-      ins(%A, %B: tensor<32x16xf32>, tensor<32x16xf32>) outs(%C: tensor<32x16xf32>) {
-        ^bb0(%a: f32, %b: f32, %c: f32):
+      ins(%A : tensor<32x16xf32>) outs(%B: tensor<32x16xf32>) {
+        ^bb0(%a: f32, %b: f32):
           %0 = arith.addf %a, %b : f32
           linalg.yield %0: f32
       } -> tensor<32x16xf32>
@@ -125,8 +125,7 @@ module {
 
     ]> : tensor<32x16xf32>
 
-    %C = arith.constant dense<0.0> : tensor<32x16xf32>
-    %0 = call @bigadd(%da, %db, %C) : (tensor<32x16xf32>, tensor<32x16xf32>, tensor<32x16xf32>) -> tensor<32x16xf32>
+    %0 = call @bigadd(%da, %db) : (tensor<32x16xf32>, tensor<32x16xf32>) -> tensor<32x16xf32>
 
     // 
     // CHECK: (     ( 2.2, 4.2, 6.2, 8.2, 10.2, 12.2, 14.2, 16.2, 18.2, 20.2, 22.2, 24.2, 26.2, 28.2, 30.2, 32.2 ), 

--- a/test/TPP/simple-match-and-replace.mlir
+++ b/test/TPP/simple-match-and-replace.mlir
@@ -3,13 +3,12 @@
 // RUN: tpp-opt %s -split-input-file -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -map-linalg-to-tpp -convert-linalg-to-tpp | FileCheck %s
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
-#map1 = affine_map<(d0, d1) -> (d0, d1)>
 
 // CHECK-LABEL: func.func @identity
 func.func @identity(%arg1: tensor<1x512xf32>) -> tensor<1x512xf32> {
   %0 = tensor.empty() : tensor<1x512xf32>
   // CHECK: tpp.identity
-  %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<1x512xf32>) outs(%0 : tensor<1x512xf32>) {
+  %1 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<1x512xf32>) outs(%0 : tensor<1x512xf32>) {
     ^bb0(%arg2: f32, %arg3: f32):
       linalg.yield %arg2 : f32
   } -> tensor<1x512xf32> 
@@ -18,14 +17,13 @@ func.func @identity(%arg1: tensor<1x512xf32>) -> tensor<1x512xf32> {
 
 // -----
 
-#map2 = affine_map<(d0, d1) -> (d0, d1)>
-#map3 = affine_map<(d0, d1) -> (d0, d1)>
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
 
 // CHECK-LABEL: func.func @relu
 func.func @relu(%arg1: tensor<1x512xf32>) -> tensor<1x512xf32> {
   %0 = tensor.empty() : tensor<1x512xf32>
   // CHECK: tpp.relu
-  %1 = linalg.generic {indexing_maps = [#map2, #map3], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<1x512xf32>) outs(%0 : tensor<1x512xf32>) {
+  %1 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<1x512xf32>) outs(%0 : tensor<1x512xf32>) {
     ^bb0(%arg2: f32, %arg3: f32):
       %2 = mathx.relu %arg2 : f32
       linalg.yield %2 : f32
@@ -35,16 +33,13 @@ func.func @relu(%arg1: tensor<1x512xf32>) -> tensor<1x512xf32> {
 
 // -----
 
-#map4 = affine_map<(d0, d1) -> (d0, d1)>
-#map5 = affine_map<(d0, d1) -> (d0, d1)>
-#map6 = affine_map<(d0, d1) -> (d0, d1)>
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
 
 // CHECK-LABEL: func.func @add
 func.func @add(%arg1: tensor<256x256xf32>, %arg2: tensor<256x256xf32>) -> tensor<256x256xf32> {
-  %0 = tensor.empty() : tensor<256x256xf32>
   // CHECK: tpp.add
-  %1 = linalg.generic {indexing_maps = [#map4, #map5, #map6], iterator_types = ["parallel", "parallel"]} ins(%arg1, %arg2: tensor<256x256xf32>, tensor<256x256xf32>) outs(%0 : tensor<256x256xf32>) {
-  ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+  %1 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<256x256xf32>) outs(%arg2 : tensor<256x256xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32):
     %2 = arith.addf %arg3, %arg4 : f32
     linalg.yield %2 : f32
   } -> tensor<256x256xf32>
@@ -53,14 +48,14 @@ func.func @add(%arg1: tensor<256x256xf32>, %arg2: tensor<256x256xf32>) -> tensor
 
 // -----
 
-#map7 = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map8 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map9 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
 // CHECK-LABEL: func.func @gemm
 func.func @gemm(%arg0: tensor<1x256xf32>, %arg1: tensor<256x512xf32>, %arg2: tensor<1x512xf32>) -> tensor<1x512xf32> {
   // CHECK: tpp.matmul
-  %1 = linalg.generic {indexing_maps = [#map7, #map8, #map9], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1: tensor<1x256xf32>, tensor<256x512xf32>) outs(%arg2: tensor<1x512xf32>) {
+  %1 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1: tensor<1x256xf32>, tensor<256x512xf32>) outs(%arg2: tensor<1x512xf32>) {
   ^bb0(%arg5: f32, %arg3: f32, %arg4: f32):
     %2 = arith.mulf %arg5, %arg3 : f32
     %3 = arith.addf %arg4, %2 : f32
@@ -71,14 +66,14 @@ func.func @gemm(%arg0: tensor<1x256xf32>, %arg1: tensor<256x512xf32>, %arg2: ten
 
 // -----
 
-#map10 = affine_map<(d0, d1, d2) -> (d0, d2)>
-#map11 = affine_map<(d0, d1, d2) -> (d2, d1)>
-#map12 = affine_map<(d0, d1, d2) -> (d0, d1)>
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
 // CHECK-LABEL: func.func @gemm
 func.func @gemm(%arg0: tensor<1x256xf32>, %arg1: tensor<256x512xf32>, %arg2: tensor<1x512xf32>) -> tensor<1x512xf32> {
   // CHECK-NOT: tpp.matmul
-  %1 = linalg.generic {indexing_maps = [#map10, #map11, #map12], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1: tensor<1x256xf32>, tensor<256x512xf32>) outs(%arg2: tensor<1x512xf32>) {
+  %1 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1: tensor<1x256xf32>, tensor<256x512xf32>) outs(%arg2: tensor<1x512xf32>) {
   ^bb0(%arg5: f32, %arg3: f32, %arg4: f32):
     %2 = arith.addf %arg5, %arg3 : f32
     %3 = arith.addf %arg4, %2 : f32
@@ -89,18 +84,17 @@ func.func @gemm(%arg0: tensor<1x256xf32>, %arg1: tensor<256x512xf32>, %arg2: ten
 
 // -----
 
-#map13 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
-#map14 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
 
 func.func @identity(%arg1: tensor<32x33x34x35xf32>) -> tensor<32x33x34x35xf32> {
   %0 = tensor.empty() : tensor<32x33x34x35xf32>
   // CHECK: tpp.identity
-  %1 = linalg.generic {indexing_maps = [#map13, #map14], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg1 : tensor<32x33x34x35xf32>) outs(%0 : tensor<32x33x34x35xf32>) {
+  %1 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg1 : tensor<32x33x34x35xf32>) outs(%0 : tensor<32x33x34x35xf32>) {
     ^bb0(%arg2: f32, %arg3: f32):
       linalg.yield %arg2 : f32
   } -> tensor<32x33x34x35xf32>
   // CHECK: tpp.identity
-  %2 = linalg.generic {indexing_maps = [#map13, #map14], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg1 : tensor<32x33x34x35xf32>) outs(%1 : tensor<32x33x34x35xf32>) {
+  %2 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%arg1 : tensor<32x33x34x35xf32>) outs(%1 : tensor<32x33x34x35xf32>) {
     ^bb0(%arg2: f32, %arg3: f32):
       linalg.yield %arg2 : f32
   } -> tensor<32x33x34x35xf32>

--- a/test/TPP/simple-match.mlir
+++ b/test/TPP/simple-match.mlir
@@ -37,14 +37,12 @@ func.func @relu(%arg1: tensor<1x512xf32>) -> tensor<1x512xf32> {
 
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
-#map2 = affine_map<(d0, d1) -> (d0, d1)>
 
 // CHECK-LABEL: func.func @add
 func.func @add(%arg1: tensor<256x256xf32>, %arg2: tensor<256x256xf32>) -> tensor<256x256xf32> {
-  %0 = tensor.empty() : tensor<256x256xf32>
   // CHECK: library_call = "tpp.add"
-  %1 = linalg.generic {indexing_maps = [#map0, #map1, #map2], iterator_types = ["parallel", "parallel"]} ins(%arg1, %arg2: tensor<256x256xf32>, tensor<256x256xf32>) outs(%0 : tensor<256x256xf32>) {
-  ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):
+  %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg1 : tensor<256x256xf32>) outs(%arg2 : tensor<256x256xf32>) {
+  ^bb0(%arg3: f32, %arg4: f32):
     %2 = arith.addf %arg3, %arg4 : f32
     linalg.yield %2 : f32
   } -> tensor<256x256xf32>
@@ -110,12 +108,11 @@ func.func @identity(%arg1: tensor<32x32x32x32xf32>) -> tensor<32x32x32x32xf32> {
 #map0 = affine_map<(d0) -> (d0)>
 
 // CHECK-LABEL: func.func @add
-func.func @add(%arga: tensor<32xf32>, %argb: f32) -> tensor<32xf32> {
-  %argx = tensor.empty() : tensor<32xf32>
+func.func @add(%arga: tensor<32xf32>, %argb: tensor<32xf32>) -> tensor<32xf32> {
   // CHECK: library_call = "tpp.add"
-  %1 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel"]} ins(%arga: tensor<32xf32>) outs(%argx: tensor<32xf32>) {
-    ^bb0(%a: f32, %x: f32):
-      %0 = arith.addf %a, %argb : f32
+  %1 = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel"]} ins(%arga: tensor<32xf32>) outs(%argb: tensor<32xf32>) {
+    ^bb0(%a: f32, %b: f32):
+      %0 = arith.addf %a, %b : f32
       linalg.yield %0 : f32
   } -> tensor<32xf32>
   return %1: tensor<32xf32>

--- a/test/TPP/tiling.mlir
+++ b/test/TPP/tiling.mlir
@@ -19,12 +19,12 @@ func.func @bigrelu(%B: tensor<256x16xf32>) -> tensor<256x16xf32> attributes {llv
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 
 func.func @bigadd(%A: tensor<32x256xf32>,
-                  %B: tensor<32x256xf32>, %C: tensor<32x256xf32>) -> tensor<32x256xf32> attributes {llvm.emit_c_interface} {
+                  %B: tensor<32x256xf32>) -> tensor<32x256xf32> attributes {llvm.emit_c_interface} {
     // CHECK: scf.for
-    %O = linalg.generic { indexing_maps = [#map0, #map0, #map0],
+    %O = linalg.generic { indexing_maps = [#map0, #map0],
                         iterator_types = ["parallel", "parallel"] }
-      ins(%A, %B: tensor<32x256xf32>, tensor<32x256xf32>) outs(%C: tensor<32x256xf32>) {
-        ^bb0(%a: f32, %b: f32, %c: f32):
+      ins(%A : tensor<32x256xf32>) outs(%B: tensor<32x256xf32>) {
+        ^bb0(%a: f32, %b: f32):
           %0 = arith.addf %a, %b : f32
           linalg.yield %0: f32
       } -> tensor<32x256xf32>

--- a/test/TPP/tpp-ops.mlir
+++ b/test/TPP/tpp-ops.mlir
@@ -5,11 +5,7 @@ func.func @myfunc(%arg0: memref<2x2xf32>,
                   %arg1: memref<2x2xf32>, 
                   %arg2: memref<2x2xf32>, %arg3: f32, %arg4: f32) -> memref<2x2xf32> {
   // CHECK: tpp.add
-  tpp.add ins(%arg0: memref<2x2xf32>, %arg1: memref<2x2xf32>) 
-          out(%arg2: memref<2x2xf32>)
-
-  // CHECK: tpp.add
-  tpp.add ins(%arg3: f32, %arg3: f32) out(%arg4: f32)
+  tpp.add ins(%arg0: memref<2x2xf32>) out(%arg2: memref<2x2xf32>)
 
   // CHECK: tpp.identity
   tpp.identity ins(%arg0: memref<2x2xf32>) out(%arg2: memref<2x2xf32>)
@@ -47,7 +43,24 @@ func.func @identityBcastCol(%arg0: memref<5xf32>, %arg1: memref<6x5xf32>) {
 // CHECK-LABEL: func.func @testBrgemm
 func.func @testBrgemm(%arg0: memref<2x5x4xf32>, %arg1: memref<2x4x5xf32>,
                       %arg2: memref<5x5xf32>) -> memref<5x5xf32> {
+  // CHECK: tpp.brgemm
   tpp.brgemm ins(%arg0: memref<2x5x4xf32>, %arg1: memref<2x4x5xf32>)
              out(%arg2: memref<5x5xf32>)
   return %arg2: memref<5x5xf32>
+}
+
+// CHECK-LABEL: func.func @testGemmWithBf16
+func.func @testGemmWithBf16(%arg0: memref<3x5x2xbf16>, %arg1: memref<5x6xbf16>, 
+                            %arg2: memref<6x6xbf16>) -> memref<6x6xbf16> {
+  // CHECK: tpp.matmul
+  tpp.matmul ins(%arg0: memref<3x5x2xbf16>, %arg1: memref<5x6xbf16>) out(%arg2: memref<6x6xbf16>)
+  return %arg2: memref<6x6xbf16>
+}
+
+// CHECK-LABEL: func.func @testBrgemmWithBf16
+func.func @testBrgemmWithBf16(%arg0: memref<32x4x4x2xbf16>, %arg1: memref<64x4x4xbf16>, 
+                              %arg2: memref<4x4xbf16>) -> memref<4x4xbf16> {
+  // CHECK: tpp.brgemm
+  tpp.brgemm ins(%arg0: memref<32x4x4x2xbf16>, %arg1: memref<64x4x4xbf16>) out(%arg2: memref<4x4xbf16>)
+  return %arg2: memref<4x4xbf16>
 }

--- a/test/TPP/tpp-to-loops.mlir
+++ b/test/TPP/tpp-to-loops.mlir
@@ -42,12 +42,12 @@ func.func @add_to_loops(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   // CHECK: scf.for %[[i:.*]] = %[[lb]] to %[[ub]] step %[[step]] {
   // CHECK:   scf.for %[[j:.*]] = %[[lb]] to %[[ub]] step %[[step]] {
   // CHECK:     %[[load1:.*]] = memref.load %arg0[%[[i]], %[[j]]] : memref<3x3xf32>
-  // CHECK:     %[[load2:.*]] = memref.load %arg0[%[[i]], %[[j]]] : memref<3x3xf32>
+  // CHECK:     %[[load2:.*]] = memref.load %arg1[%[[i]], %[[j]]] : memref<3x3xf32>
   // CHECK:     %[[add:.*]] = arith.addf %[[load1]], %[[load2]] : f32
   // CHECK:     memref.store %[[add]], %arg1[%[[i]], %[[j]]] : memref<3x3xf32>
   // CHECK:   }
   // CHECK: }
-  tpp.add ins(%arg0: memref<3x3xf32>, %arg0: memref<3x3xf32>) out(%arg1: memref<3x3xf32>)
+  tpp.add ins(%arg0: memref<3x3xf32>) out(%arg1: memref<3x3xf32>)
   return 
 }
 
@@ -78,27 +78,6 @@ func.func @identity_to_loops_scalar(%arg0: f32, %arg1: f32) -> f32 {
   return %0: f32
 }
 
-// -----
-
-// CHECK-LABEL: @add_to_loops_scalar(
-// CHECK-SAME: %[[arg_zero:.*]]: f32, %[[arg_one:.*]]: f32, %[[arg_two:.*]]: f32)
-func.func @add_to_loops_scalar(%arg0: f32, %arg1: f32, %arg2: f32) -> f32 {
-  // CHECK: %[[res:.*]] = arith.addf %[[arg_zero]], %[[arg_one]] : f32
-  tpp.add ins(%arg0: f32, %arg1: f32) out(%arg2: f32)
-  // CHECK: return %[[res]] : f32
-  return %arg2: f32
-}
-
-// -----
-
-// CHECK-LABEL: @relu_to_loops_scalar(
-// CHECK-SAME: %[[arg_zero:.*]]: f32, %[[arg_one:.*]]: f32)
-func.func @relu_to_loops_scalar(%arg0: f32, %arg1: f32) -> f32 {
-  // CHECK %[[res:.*]] = mathx.relu %[[arg_zero]] : f32
-  tpp.relu ins(%arg0: f32) out(%arg1: f32)
-  // CHECK: return %[[res]] : f32
-  return %arg1: f32
-}
 
 // -----
 

--- a/tpp-rt/XsmmRunnerUtils.cpp
+++ b/tpp-rt/XsmmRunnerUtils.cpp
@@ -331,16 +331,13 @@ _mlir_ciface_xsmm_unary_invoke_bf16(int64_t addr,
 
 extern "C" void
 _mlir_ciface_xsmm_binary_invoke(int64_t addr, UnrankedMemRefType<float> *lhs,
-                                UnrankedMemRefType<float> *rhs,
-                                UnrankedMemRefType<float> *output) {
+                                UnrankedMemRefType<float> *rhs) {
 
   DynamicMemRefType<float> tensorLhs = DynamicMemRefType<float>(*lhs);
   DynamicMemRefType<float> tensorRhs = DynamicMemRefType<float>(*rhs);
-  DynamicMemRefType<float> tensorOut = DynamicMemRefType<float>(*output);
 
   float *addr_tensor_lhs = tensorLhs.data + tensorLhs.offset;
   float *addr_tensor_rhs = tensorRhs.data + tensorRhs.offset;
-  float *addr_tensor_out = tensorOut.data + tensorOut.offset;
 
   libxsmm_meltwfunction_binary kernel =
       reinterpret_cast<libxsmm_meltwfunction_binary>(addr);
@@ -348,7 +345,7 @@ _mlir_ciface_xsmm_binary_invoke(int64_t addr, UnrankedMemRefType<float> *lhs,
   // TODO: check if we need to swap also here.
   param.in0.primary = (void *)addr_tensor_lhs;
   param.in1.primary = (void *)addr_tensor_rhs;
-  param.out.primary = (void *)addr_tensor_out;
+  param.out.primary = (void *)addr_tensor_rhs;
   kernel(&param);
 }
 

--- a/tpp-rt/XsmmRunnerUtils.h
+++ b/tpp-rt/XsmmRunnerUtils.h
@@ -67,7 +67,6 @@ _mlir_ciface_xsmm_unary_invoke_bf16(int64_t, UnrankedMemRefType<bf16> *,
 
 extern "C" MLIR_RUNNERUTILS_EXPORT void
 _mlir_ciface_xsmm_binary_invoke(int64_t, UnrankedMemRefType<float> *,
-                                UnrankedMemRefType<float> *,
                                 UnrankedMemRefType<float> *);
 
 extern "C" MLIR_RUNNERUTILS_EXPORT void


### PR DESCRIPTION
Originally the tpp.add was accepting 2 inputs and 1 output. This would allow us to write something like A += B + C (note the +=) and it was not in-line with the TPP specification. Allow only 1 input and 1 output and effectively implement A = A + B.