### PR TITLE
Refactoring xsmm backend

### DIFF
--- a/lib/TPP/CMakeLists.txt
+++ b/lib/TPP/CMakeLists.txt
@@ -37,13 +37,14 @@ add_mlir_library(MLIRTPP
     TPPCompilerPassIncGen
     TPPLinalgXTransformOps
 
-	LINK_LIBS PUBLIC
+  LINK_LIBS PUBLIC
     TPPLinalgXDialect
     TPPMathxDialect
     TPPStdxDialect
     TPPTppDialect
     TPPXsmmDialect
-    
+    xsmm
+ 
     MLIRIR
     MLIRInferTypeOpInterface
 )


### PR DESCRIPTION
Currently, I see a build failure with the following error
```
In file included from /nfs_home/kmadhu/tpp_sandbox/tpp-sandbox/build/_deps/xsmm-src/include/libxsmm.h:14,
                 from /nfs_home/kmadhu/tpp_sandbox/tpp-sandbox/lib/TPP/ConvertXsmmToFunc.cpp:18:
/nfs_home/kmadhu/tpp_sandbox/tpp-sandbox/build/_deps/xsmm-src/include/libxsmm_config.h:12:12: fatal error: libxsmm_version.h: No such file or directory
   12 | #  include "libxsmm_version.h"
```
@chelini Can you please check the CMakeLists.txt and let me know if I have missed something? 

