### PR TITLE
Introduce `MapLinalgToTppOp`

### DIFF
--- a/include/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
+++ b/include/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
@@ -171,4 +171,40 @@ def PackingPropagationOp : Op<Transform_Dialect, "structured.packing_propagation
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// MapLinalgToTppOp
+//===----------------------------------------------------------------------===//
+
+def MapLinalgToTppOp : Op<Transform_Dialect, "structured.map_linalg_to_tpp", [
+    FunctionalStyleTransformOpTrait,
+    MemoryEffectsOpInterface,
+    TransformEachOpTrait, 
+    TransformOpInterface]> {
+  
+  let description = [{
+    Pattern match a linalg.generic and map it to tpp operations. On success,
+    the resulting operation will still be a linalg.generic with the library_call
+    set with the name of the tpp operation detected. Internally, it applies a set
+    of rewrite patterns. Therefore, it can only be applied to an op with the
+    "isolated from above property".
+
+    Note that this transformation is invalidating the handles to any payload IR
+    operation contained in the target operation.
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $target attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::llvm::SmallVector<::mlir::Operation *> &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // LINALG_TRANSFORM_OPS

--- a/test/TPP/transform/detect-tpp.mlir
+++ b/test/TPP/transform/detect-tpp.mlir
@@ -3,7 +3,7 @@
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
 func.func @relu(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
-  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"], library_call = "tpp.relu"} outs(%arg0: tensor<128x128xf32>) {
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%arg0: tensor<128x128xf32>) {
     ^bb0(%out: f32):
       %1 = mathx.relu %out : f32
       linalg.yield %1 : f32

--- a/test/TPP/transform/detect-tpp.mlir
+++ b/test/TPP/transform/detect-tpp.mlir
@@ -1,0 +1,43 @@
+// RUN: tpp-opt -transform-dialect-interpreter -verify-diagnostics -split-input-file %s | FileCheck %s
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @relu(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"], library_call = "tpp.relu"} outs(%arg0: tensor<128x128xf32>) {
+    ^bb0(%out: f32):
+      %1 = mathx.relu %out : f32
+      linalg.yield %1 : f32
+  } -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+transform.sequence failures(propagate) {
+  ^bb0(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["func.func"]} in %arg1
+    transform.structured.map_linalg_to_tpp %0
+}
+
+// CHECK: func.func @relu(
+// CHECK-SAME: %[[ARG0:[0-9a-z]+]]: tensor<128x128xf32>) -> tensor<128x128xf32> {
+// CHECK: {{.*}} = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"], library_call = "tpp.relu"} outs(%[[ARG0]] : tensor<128x128xf32>)
+
+// -----
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @relu(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
+  // expected-note @below {{non-isolated target}}
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"], library_call = "tpp.relu"} outs(%arg0: tensor<128x128xf32>) {
+    ^bb0(%out: f32):
+      %1 = mathx.relu %out : f32
+      linalg.yield %1 : f32
+  } -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+transform.sequence failures(propagate) {
+  ^bb0(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
+    // expected-error @below {{op requires isolated-from-above targets}}
+    transform.structured.map_linalg_to_tpp %0
+}


### PR DESCRIPTION
The op runs `populateMapLinalgToTppPatterns` to annotate linalg.generic operations with attributes that represent mappable tpp operations.