### PR TITLE
Propagate `outer_dim_pos` in padding

### DIFF
--- a/lib/TPP/ToBlockLayoutAndBack.cpp
+++ b/lib/TPP/ToBlockLayoutAndBack.cpp
@@ -553,6 +553,8 @@ struct PropagateThroughPadOp : public OpRewritePattern<tensor::PadOp> {
     if (paddedDims.anyCommon(innerDims))
       return failure();
 
+    SmallVector<int64_t> outerDimsPerm =
+        extractFromI64ArrayAttr(unpackOp.getOuterDimsPerm());
     SmallVector<OpFoldResult> lowPad = padOp.getMixedLowPad();
     SmallVector<OpFoldResult> highPad = padOp.getMixedHighPad();
     if (!outerDimsPerm.empty()) {

--- a/test/TPP/pack-unpack-propagation.mlir
+++ b/test/TPP/pack-unpack-propagation.mlir
@@ -218,4 +218,44 @@ func.func @conv(%arg0: tensor<1x56x56x64xf32>, %arg1: tensor<1x1x64x64xf32>, %ar
 // CONV: %[[BUFF4:.+]] = tensor.empty() : tensor<1x2x56x56x32xf32>
 // CONV: %[[PACK4:.+]] = linalgx.pack %[[ARG2]] outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %[[BUFF4]] : (tensor<1x56x56x64xf32> tensor<1x2x56x56x32xf32>) -> tensor<1x2x56x56x32xf32>
 // CONV: %[[VAL1:.+]] = linalg.generic {indexing_maps = [#[[MAP3]], #[[MAP4]], #[[MAP3]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} ins(%[[VAL]], %[[PACK3]] : tensor<1x2x56x56x32xf32>, tensor<2x56x32xf32>) outs(%[[PACK4]] : tensor<1x2x56x56x32xf32>)
-// CONV: %[[UNPACK:.+]] = linalgx.unpack %[[VAL1]] outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %[[ARG2]] : (tensor<1x2x56x56x32xf32> tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32> 
+// CONV: %[[UNPACK:.+]] = linalgx.unpack %[[VAL1]] outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %[[ARG2]] : (tensor<1x2x56x56x32xf32> tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+
+// -----
+
+#map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+
+func.func @conv(%arg0: tensor<1x56x56x64xf32>, %arg1: tensor<1x1x64x64xf32>, %arg2: tensor<1x56x56x64xf32>) -> tensor<1x58x58x64xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf ins(%arg0, %arg1: tensor<1x56x56x64xf32>, tensor<1x1x64x64xf32>) outs(%arg2: tensor<1x56x56x64xf32>) -> tensor<1x56x56x64xf32>
+  %1 = linalg.generic {indexing_maps = [#map0], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} outs(%0 : tensor<1x56x56x64xf32>) {
+    ^bb0(%in: f32):
+      %13 = mathx.relu %in : f32
+      linalg.yield %13 : f32
+  } -> tensor<1x56x56x64xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %2 = tensor.pad %1 low[0, 1, 1, 0] high[0, 1, 1, 0] {
+    ^bb0(%arg3: index, %arg4: index, %arg5: index, %arg6: index):
+      tensor.yield %cst : f32
+  } : tensor<1x56x56x64xf32> to tensor<1x58x58x64xf32>
+  return %2 : tensor<1x58x58x64xf32>
+}
+
+// CONV-DAG: #[[MAP0:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d5, d2 + d6, d3 + d7, d8)>
+// CONV-DAG: #[[MAP1:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d1, d5, d6, d7, d8, d4)>
+// CONV-DAG: #[[MAP2:.+]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8) -> (d0, d1, d2, d3, d4)>
+// CONV-DAG: #[[MAP3:.+]] = affine_map<(d0, d1, d2, d3, d4) -> (d0, d1, d2, d3, d4)>
+// CONV: func.func @conv(
+// CONV-SAME: %[[ARG0:.+]]: tensor<1x56x56x64xf32>,
+// CONV-SAME: %[[ARG1:.+]]: tensor<1x1x64x64xf32>,
+// CONV-SAME: %[[ARG2:.+]]: tensor<1x56x56x64xf32>) -> tensor<1x58x58x64xf32> {
+// CONV: %[[BUFF0:.+]] = tensor.empty() : tensor<1x2x56x56x32xf32>
+// CONV: %[[PACK0:.+]] = linalgx.pack %[[ARG0]] outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %[[BUFF0]] : (tensor<1x56x56x64xf32> tensor<1x2x56x56x32xf32>) -> tensor<1x2x56x56x32xf32>
+// CONV: %[[BUFF1:.+]] = tensor.empty() : tensor<2x2x1x1x32x32xf32>
+// CONV: %[[PACK1:.+]] = linalgx.pack %[[ARG1]] outer_dims_perm = [3, 2, 0, 1] inner_dims_pos = [2, 3] inner_tiles = [32, 32] into %[[BUFF1]] : (tensor<1x1x64x64xf32> tensor<2x2x1x1x32x32xf32>) -> tensor<2x2x1x1x32x32xf32>
+// CONV: %[[BUFF2:.+]] = tensor.empty() : tensor<1x2x56x56x32xf32>
+// CONV: %[[PACK2:.+]] = linalgx.pack %[[ARG2]] outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %[[BUFF2]] : (tensor<1x56x56x64xf32> tensor<1x2x56x56x32xf32>) -> tensor<1x2x56x56x32xf32>
+// CONV: %[[VAL:.+]] = linalg.generic {indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel", "reduction", "reduction", "reduction", "reduction"]} ins(%[[PACK0]], %[[PACK1]] : tensor<1x2x56x56x32xf32>, tensor<2x2x1x1x32x32xf32>) outs(%[[PACK2]] : tensor<1x2x56x56x32xf32>)
+// CONV: %[[VAL1:.+]] = linalg.generic {indexing_maps = [#[[MAP3]]], iterator_types = ["parallel", "parallel", "parallel", "parallel", "parallel"]} outs(%[[VAL]] : tensor<1x2x56x56x32xf32>)
+// CONV: %[[PADDED:.+]] = tensor.pad %[[VAL1]] low[0, 0, 1, 1, 0] high[0, 0, 1, 1, 0] 
+// CONV: %[[OUT:.+]] = tensor.empty() : tensor<1x58x58x64xf32>
+// CONV: %[[UNPACK:.+]] = linalgx.unpack %[[PADDED]] outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %[[OUT]] : (tensor<1x2x58x58x32xf32> tensor<1x58x58x64xf32>) -> tensor<1x58x58x64xf32>
+// CONV: return %[[UNPACK]] : tensor<1x58x58x64xf32> 


### PR DESCRIPTION
We used to bail out if `outer_dims_pos` (aka transposition for tiled loops) was available in unpack operations when propagatin through pad operations. As `outer_dims_pos` appears in convolutions we need to handle it.