### PR TITLE
Use transform to optimize MLP

### DIFF
--- a/include/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
+++ b/include/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
@@ -207,4 +207,39 @@ def MapLinalgToTppOp : Op<Transform_Dialect, "structured.map_linalg_to_tpp", [
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// FoldUnitExtentDimsOp
+//===----------------------------------------------------------------------===//
+
+def FoldUnitExtentDimsOp : Op<Transform_Dialect, "structured.fold_unit_extent_dims", [
+    FunctionalStyleTransformOpTrait,
+    MemoryEffectsOpInterface,
+    TransformEachOpTrait,
+    TransformOpInterface]> {
+
+  let description = [{
+    Pattern to canonicalize unit-extent dims. It is a wrapper for
+    `populateFoldUnitExtentDimsPatterns`.  Internally, it applies a set of rewrite
+    patterns. Therefore, it can only be applied to an op with the "isolated from
+    above property".
+
+    Note that this transformation is invalidating the handles to any payload IR
+    operation contained in the target operation.
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs);
+
+  let assemblyFormat = [{
+    $target attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::llvm::SmallVector<::mlir::Operation *> &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // LINALG_TRANSFORM_OPS

--- a/include/TPP/Passes.h
+++ b/include/TPP/Passes.h
@@ -77,6 +77,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createTransformDialectInterpreterPass()
 std::unique_ptr<OperationPass<func::FuncOp>> createIteratorCollapsingPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgXToLoopsPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createPackConv2DNhwcHwcfPass();
+std::unique_ptr<OperationPass<ModuleOp>> createTransformDropSchedulePass();
 
 } // namespace tpp
 } // namespace mlir

--- a/include/TPP/Passes.td
+++ b/include/TPP/Passes.td
@@ -226,4 +226,9 @@ def LinalgExtToLoops :
   let constructor = "mlir::tpp::createLinalgXToLoopsPass()";
 }
 
+def TransformDropSchedulePass : Pass<"transform-drop-schedule", "ModuleOp"> {
+  let summary = "Drop the transform schedule";
+  let constructor = "mlir::tpp::createTransformDropSchedulePass()";
+}
+
 #endif // TPP_DIALECT_TPP_PASSES

--- a/lib/TPP/TransformDialectInterpreter.cpp
+++ b/lib/TPP/TransformDialectInterpreter.cpp
@@ -38,9 +38,27 @@ struct TransformDialectInterpreter
   }
 };
 
+struct TransformDropSchedulePass
+    : TransformDropSchedulePassBase<TransformDropSchedulePass> {
+  void runOnOperation() override {
+    getOperation()->walk<WalkOrder::PreOrder>([&](Operation *nestedOp) {
+      if (isa<::mlir::transform::TransformOpInterface>(nestedOp)) {
+        nestedOp->erase();
+        return WalkResult::skip();
+      }
+      return WalkResult::advance();
+    });
+  }
+};
+
 } // namespace
 
 std::unique_ptr<OperationPass<ModuleOp>>
 mlir::tpp::createTransformDialectInterpreterPass() {
   return std::make_unique<TransformDialectInterpreter>();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::tpp::createTransformDropSchedulePass() {
+  return std::make_unique<TransformDropSchedulePass>();
 }

--- a/test/TPP/transform/drop-schedule.mlir
+++ b/test/TPP/transform/drop-schedule.mlir
@@ -1,0 +1,20 @@
+// RUN: tpp-opt -transform-dialect-interpreter -transform-drop-schedule %s | FileCheck %s
+
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @relu(%arg0: tensor<128x128xf32>) -> tensor<128x128xf32> {
+  // CHECK: tpp.relu
+  %0 = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel", "parallel"]} outs(%arg0: tensor<128x128xf32>) {
+    ^bb0(%out: f32):
+      %1 = mathx.relu %out : f32
+      linalg.yield %1 : f32
+  } -> tensor<128x128xf32>
+  return %0 : tensor<128x128xf32>
+}
+
+// CHECK-NOT: transform.sequence
+transform.sequence failures(propagate) {
+  ^bb0(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["func.func"]} in %arg1
+    transform.structured.map_linalg_to_tpp %0
+}

--- a/test/TPP/transform/mlp.mlir
+++ b/test/TPP/transform/mlp.mlir
@@ -1,0 +1,106 @@
+// RUN: tpp-opt %s -transform-dialect-interpreter -transform-drop-schedule -canonicalize | FileCheck %s
+
+#map0 = affine_map<(d0, d1) -> (d1)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module @predict_function  {
+  func.func @main(%arg0: tensor<128x256xf32>, %arg1: tensor<256x512xf32>,
+                  %arg2: tensor<512xf32>, %arg3: tensor<512x1024xf32>,
+                  %arg4: tensor<1024xf32>, %arg5: tensor<1024x2048xf32>,
+                  %arg6: tensor<2048xf32>, %arg7: tensor<2048x1024xf32>,
+                  %arg8: tensor<1024xf32>, %output: tensor<128x1024xf32>,
+                  %output1: tensor<128x2048xf32>, %output2: tensor<128x1024xf32>,
+                  %ouput3: tensor<128x512xf32>) -> tensor<128x1024xf32> {
+    %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg2 : tensor<512xf32>) outs(%ouput3 : tensor<128x512xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      linalg.yield %arg9 : f32
+    } -> tensor<128x512xf32>
+    %2 = linalg.matmul ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>) outs(%1 : tensor<128x512xf32>) -> tensor<128x512xf32> 
+    %3 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<128x512xf32>) outs(%ouput3 : tensor<128x512xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      %16 = mathx.relu %arg9 : f32
+      linalg.yield %16 : f32
+    } -> tensor<128x512xf32>
+    %5 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg4 : tensor<1024xf32>) outs(%output2 : tensor<128x1024xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      linalg.yield %arg9 : f32
+    } -> tensor<128x1024xf32>
+    %6 = linalg.matmul ins(%3, %arg3 : tensor<128x512xf32>, tensor<512x1024xf32>) outs(%5 : tensor<128x1024xf32>) -> tensor<128x1024xf32> 
+    %7 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%6 : tensor<128x1024xf32>) outs(%output2 : tensor<128x1024xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      %16 = mathx.relu %arg9 : f32
+      linalg.yield %16 : f32
+    } -> tensor<128x1024xf32>
+    %9 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg6 : tensor<2048xf32>) outs(%output1 : tensor<128x2048xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      linalg.yield %arg9 : f32
+    } -> tensor<128x2048xf32>
+    %10 = linalg.matmul ins(%7, %arg5 : tensor<128x1024xf32>, tensor<1024x2048xf32>) outs(%9 : tensor<128x2048xf32>) -> tensor<128x2048xf32> 
+    %11 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%10 : tensor<128x2048xf32>) outs(%output1 : tensor<128x2048xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      %16 = mathx.relu %arg9 : f32
+      linalg.yield %16 : f32
+    } -> tensor<128x2048xf32>
+    %13 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg8 : tensor<1024xf32>) outs(%output : tensor<128x1024xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      linalg.yield %arg9 : f32
+    } -> tensor<128x1024xf32>
+    %14 = linalg.matmul ins(%11, %arg7 : tensor<128x2048xf32>, tensor<2048x1024xf32>) outs(%13 : tensor<128x1024xf32>) -> tensor<128x1024xf32> 
+    %15 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%14 : tensor<128x1024xf32>) outs(%output : tensor<128x1024xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      %16 = mathx.relu %arg9 : f32
+      linalg.yield %16 : f32
+    } -> tensor<128x1024xf32>
+    return %15 : tensor<128x1024xf32>
+  }
+
+  transform.sequence failures(propagate) {
+    ^bb0(%arg1: !pdl.operation):
+      %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1
+      // Block matmul i, j and k 
+      %1 = transform.structured.pack %0 { blocking_factors = [32, 32, 32] }
+      // Get the parent op (func.func)
+      %2 = get_closest_isolated_parent %1 : (!pdl.operation) -> !pdl.operation
+      // Propagate packing
+      transform.structured.packing_propagation %2
+  }
+
+  transform.sequence failures(propagate) {
+    ^bb0(%arg1: !pdl.operation):
+      %0 = transform.structured.match ops{["func.func"]} in %arg1
+      // Annotate the relu(s)
+      transform.structured.map_linalg_to_tpp %0
+  }
+
+  transform.sequence failures(propagate) {
+    ^bb0(%arg1: !pdl.operation):
+      // Collect all the relus
+      %0 = transform.structured.match ops{["linalg.generic"]} attributes{library_call = "tpp.relu"} in %arg1
+      // Get the last one, and fuse the outermost dimensions with all the producers
+      %relus:4 = split_handles %0 in [4] : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+      %1, %loop = transform.structured.fuse %relus#3 { tile_sizes = [1, 0, 0, 0] }  
+  }
+
+  // Clean-up outer 1's dims, and re-annotate IR (fusion lost attributes info)
+  transform.sequence failures(propagate) {
+    ^bb0(%arg1: !pdl.operation):
+      %0 = transform.structured.match ops{["func.func"]} in %arg1
+      transform.structured.fold_unit_extent_dims %0
+      %1 = transform.structured.match ops{["func.func"]} in %arg1
+      transform.structured.map_linalg_to_tpp %1
+  }
+
+  transform.sequence failures(propagate) {
+    ^bb0(%arg1: !pdl.operation):  
+      %0 = transform.structured.match ops{["linalg.generic"]} attributes{library_call = "tpp.relu"} in %arg1
+      // Fuse matmul + relu and map the matmul to BRGEMM
+      %1, %loop = transform.structured.fuse %0 { tile_sizes = [1, 0, 0] }
+      %2 = get_producer_of_operand %1[0] : (!pdl.operation) -> !pdl.operation
+      transform.structured.map_to_brgemm %2
+  }
+}
+
+// We have 4 layers. 1 loop for each layer and 1 outermost loop for all the layers
+// CHECK-COUNT-5: scf.for


### PR DESCRIPTION
Using transform we can have a better control over fusion and we can generate only 5 loops. 1 loop for each layer (4 layers) + an outermost
one. Bufferization still remains a problem (see issue: #95).