### PR TITLE
Change behavior when converting to tpp

### DIFF
--- a/include/TPP/Transforms.h
+++ b/include/TPP/Transforms.h
@@ -58,7 +58,8 @@ collapseIterators(RewriterBase &rewriter, linalg::GenericOp genericOp,
 } // namespace linalgx
 
 namespace tpp {
-void populateConvertLinalgToTppPatterns(RewritePatternSet &patterns);
+void populateConvertLinalgToTppPatterns(RewritePatternSet &patterns,
+                                        bool useParallelLoops);
 void populateMapLinalgToTppPatterns(RewritePatternSet &patterns);
 void populateTppToXsmmPatterns(RewritePatternSet &patterns);
 void populateXsmmToFuncPatterns(RewritePatternSet &patterns,

--- a/test/TPP/bias-matmul-relu.mlir
+++ b/test/TPP/bias-matmul-relu.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -pack-matmul="block-factors=32,32,32" -canonicalize -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -map-to-brgemm -convert-linalg-to-tpp | FileCheck %s
+// RUN: tpp-opt %s -pack-matmul="block-factors=32,32,32" -canonicalize -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -map-to-brgemm -map-linalg-to-tpp -convert-linalg-to-tpp | FileCheck %s
 
 !A_tensor_t = tensor<256x512xf32>
 !B_tensor_t = tensor<512x1024xf32>


### PR DESCRIPTION
- Generate parallel loops as default.
- Check static shape in `checkOperandForTpp`
- Drop duplicate code
- Revert to original behavior where we have two separate passes: 1 for detection and 1 for mapping (`populateMapLinalgToTppPatterns` is not removed from `populateConvertLinalgToTppPatterns`.