### PR TITLE
Fix reshape2D

### DIFF
--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -78,6 +78,8 @@ static Value rankReducingSubviewDroppingUnitDims(OpBuilder &builder,
 // the last and first dimension only.
 LogicalResult reshape2D(RewriterBase &rewriter, linalg::GenericOp linalgOp,
                         bool useParallelLoops) {
+  if (!hasTppMark(linalgOp))
+    return rewriter.notifyMatchFailure(linalgOp, "Expect tpp mark");
   if (!linalgOp.hasBufferSemantics())
     return rewriter.notifyMatchFailure(linalgOp,
                                        "Expect linalgOp with buffer semantics");

--- a/test/BF16/matmul-pbf16.mlir
+++ b/test/BF16/matmul-pbf16.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
+// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func  -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts |\
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/BF16/mlp-all-bf16.mlir
+++ b/test/BF16/mlp-all-bf16.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
+// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts |\
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext

--- a/test/BF16/mlp-single-layer-bf16.mlir
+++ b/test/BF16/mlp-single-layer-bf16.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler |\
+// RUN: tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts |\
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext

--- a/test/BF16/mlp-single-layer-blocked-bf16.mlir
+++ b/test/BF16/mlp-single-layer-blocked-bf16.mlir
@@ -1,4 +1,4 @@
-// RUN:tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -convert-vector-to-llvm -convert-func-to-llvm -convert-memref-to-llvm -canonicalize -sparse-compiler |\
+// RUN:tpp-opt %s -linalg-ext-to-loops -convert-linalg-to-loops -convert-tpp-to-xsmm -convert-xsmm-to-func -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts |\
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \

--- a/test/Integration/conv-mapping-to-gemm.mlir
+++ b/test/Integration/conv-mapping-to-gemm.mlir
@@ -1,18 +1,16 @@
-// RUN: tpp-opt %s -decompose-conv-to-matmul-or-brgemm -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler | \
+// RUN: tpp-opt %s -decompose-conv-to-matmul-or-brgemm -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts | \
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
 //
 
-// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -sparse-compiler | \
+// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts | \
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \
 // RUN: FileCheck --check-prefixes=CHECK-NOOPT %s
 //
-
-// TODO: we probably miss a pass and we abuse sparse-compiler to lower.
 
 module {
 

--- a/test/Integration/conv-on-loops.mlir
+++ b/test/Integration/conv-on-loops.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -convert-tpp-to-loops -sparse-compiler | \
+// RUN: tpp-opt %s -convert-tpp-to-loops -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts | \
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \

--- a/test/Integration/conv-on-tensor.mlir
+++ b/test/Integration/conv-on-tensor.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -sparse-compiler | \
+// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts | \
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \

--- a/test/Integration/relayout-gemm.mlir
+++ b/test/Integration/relayout-gemm.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -pre-bufferization -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -sparse-compiler | \
+// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts | \
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \

--- a/test/Integration/relayout-more-interesting.mlir
+++ b/test/Integration/relayout-more-interesting.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -sparse-compiler | \
+// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts | \
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \

--- a/test/Integration/subview-on-tensor.mlir
+++ b/test/Integration/subview-on-tensor.mlir
@@ -1,4 +1,4 @@
-// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -sparse-compiler | \
+// RUN: tpp-opt %s -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map"  -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize -convert-linalg-to-loops -convert-vector-to-scf -convert-scf-to-cf -lower-affine -convert-vector-to-llvm -convert-memref-to-llvm -arith-expand -convert-math-to-llvm -convert-func-to-llvm -reconcile-unrealized-casts | \
 // RUN: mlir-cpu-runner \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext | \

--- a/test/TPP/linalg-to-tpp.mlir
+++ b/test/TPP/linalg-to-tpp.mlir
@@ -51,3 +51,30 @@ func.func @matmul_lowering(%arg0: memref<8x9xf32>,
                 outs(%arg2: memref<8x8xf32>)
   return
 }
+
+// -----
+
+#map = affine_map<(d0, d1, d2, d3) -> (d3)>
+#map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+func.func @identity_mapping(%arg0: memref<64xf32>) -> memref<12x56x56x64xf32> {
+  %alloc = memref.alloc() {alignment = 128 : i64} : memref<12x56x56x64xf32>
+  linalg.generic {indexing_maps = [#map, #map1], iterator_types = ["parallel", "parallel", "parallel", "parallel"], library_call="tpp.identity" } ins(%arg0 : memref<64xf32>) outs(%alloc : memref<12x56x56x64xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      linalg.yield %in : f32
+  }
+  return %alloc : memref<12x56x56x64xf32>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1)[s0] -> (d0 * 64 + d1 + s0)>
+// CHECK: func.func @identity_mapping(
+// CHECK-SAME: %[[ARG0:.+]]: memref<64xf32>)
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C12:.+]] = arith.constant 12 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C56:.+]] = arith.constant 56 : index
+// CHECK: %[[ALLOC:.+]] = memref.alloc() {alignment = 128 : i64} : memref<12x56x56x64xf32>
+// CHECK: scf.parallel (%[[ARG1:.+]], %[[ARG2:.+]]) = (%[[C0]], %[[C0]]) to (%[[C12]], %[[C56]]) step (%[[C1]], %[[C1]]) {
+// CHECK: %[[SUB:.+]] = memref.subview %[[ALLOC]][%[[ARG1]], %[[ARG2]], 0, 0] [1, 1, 56, 64] [1, 1, 1, 1] : memref<12x56x56x64xf32> to memref<56x64xf32, #[[MAP]]>
+// CHECK: tpp.identity ins(%[[ARG0]] : memref<64xf32>) out(%[[SUB]] : memref<56x64xf32, #[[MAP]]>)
+// CHECK: scf.yield
+// CHECK: }


### PR DESCRIPTION
Reshape2D tiles a linalg.generic by stripping out all but the last two innermost loops. The tile sizes for all but the two innermost loops are essentially the whole tensor dimension. But tiling by one will always succeed and give back the same tensor, thus the infinite loop.