### PR TITLE
Add tests for benchmarks

### DIFF
--- a/test/Benchmarks/matmul_kernel_12x6x9.mlir
+++ b/test/Benchmarks/matmul_kernel_12x6x9.mlir
@@ -1,0 +1,27 @@
+// RUN: tpp-opt %s -map-linalg-to-tpp \
+// RUN:            -pre-bufferization \
+// RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
+// RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
+// RUN:            -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func | \
+// RUN: tpp-run \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
+// RUN: FileCheck %s
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func.func @entry(%A: tensor<12x9xf32>, %B: tensor<9x6xf32>,
+                  %C: tensor<12x6xf32>) -> tensor<12x6xf32> {
+  %D = linalg.generic {indexing_maps = [#map0, #map1, #map2],
+                         iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%A, %B: tensor<12x9xf32>, tensor<9x6xf32>) outs(%C: tensor<12x6xf32>) {
+      ^bb0(%a: f32, %b: f32, %c: f32):
+        %0 = arith.mulf %a, %b : f32
+        %1 = arith.addf %c, %0 : f32
+        linalg.yield %1 : f32
+    } -> tensor<12x6xf32>
+  return %D : tensor<12x6xf32>
+}
+// CHECK-COUNT-12: ( 10, 10, 10, 10, 10, 10 )

--- a/test/Benchmarks/matmul_kernel_12x6x9.mlir
+++ b/test/Benchmarks/matmul_kernel_12x6x9.mlir
@@ -1,5 +1,4 @@
 // RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN:            -pre-bufferization \
 // RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
 // RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
 // RUN:            -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func | \
@@ -25,3 +24,4 @@ func.func @entry(%A: tensor<12x9xf32>, %B: tensor<9x6xf32>,
   return %D : tensor<12x6xf32>
 }
 // CHECK-COUNT-12: ( 10, 10, 10, 10, 10, 10 )
+

--- a/test/Benchmarks/matmul_kernel_48x64x96.mlir
+++ b/test/Benchmarks/matmul_kernel_48x64x96.mlir
@@ -1,5 +1,4 @@
 // RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN:            -pre-bufferization \
 // RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
 // RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
 // RUN:            -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func | \
@@ -25,3 +24,4 @@ func.func @entry(%A: tensor<48x96xf32>, %B: tensor<96x64xf32>,
   return %D : tensor<48x64xf32>
 }
 // CHECK-COUNT-48: ( 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97 )
+

--- a/test/Benchmarks/matmul_kernel_48x64x96.mlir
+++ b/test/Benchmarks/matmul_kernel_48x64x96.mlir
@@ -1,0 +1,27 @@
+// RUN: tpp-opt %s -map-linalg-to-tpp \
+// RUN:            -pre-bufferization \
+// RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
+// RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
+// RUN:            -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func | \
+// RUN: tpp-run \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
+// RUN: FileCheck %s
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func.func @entry(%A: tensor<48x96xf32>, %B: tensor<96x64xf32>,
+                  %C: tensor<48x64xf32>) -> tensor<48x64xf32> {
+  %D = linalg.generic {indexing_maps = [#map0, #map1, #map2],
+                         iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%A, %B: tensor<48x96xf32>, tensor<96x64xf32>) outs(%C: tensor<48x64xf32>) {
+      ^bb0(%a: f32, %b: f32, %c: f32):
+        %0 = arith.mulf %a, %b : f32
+        %1 = arith.addf %c, %0 : f32
+        linalg.yield %1 : f32
+    } -> tensor<48x64xf32>
+  return %D : tensor<48x64xf32>
+}
+// CHECK-COUNT-48: ( 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97 )

--- a/test/Benchmarks/matmul_kernel_64x48x96.mlir
+++ b/test/Benchmarks/matmul_kernel_64x48x96.mlir
@@ -1,0 +1,27 @@
+// RUN: tpp-opt %s -map-linalg-to-tpp \
+// RUN:            -pre-bufferization \
+// RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
+// RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
+// RUN:            -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func | \
+// RUN: tpp-run \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
+// RUN: FileCheck %s
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func.func @entry(%A: tensor<64x96xf32>, %B: tensor<96x48xf32>,
+                  %C: tensor<64x48xf32>) -> tensor<64x48xf32> {
+  %D = linalg.generic {indexing_maps = [#map0, #map1, #map2],
+                         iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%A, %B: tensor<64x96xf32>, tensor<96x48xf32>) outs(%C: tensor<64x48xf32>) {
+      ^bb0(%a: f32, %b: f32, %c: f32):
+        %0 = arith.mulf %a, %b : f32
+        %1 = arith.addf %c, %0 : f32
+        linalg.yield %1 : f32
+    } -> tensor<64x48xf32>
+  return %D : tensor<64x48xf32>
+}
+// CHECK-COUNT-64: ( 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97 )

--- a/test/Benchmarks/matmul_kernel_64x48x96.mlir
+++ b/test/Benchmarks/matmul_kernel_64x48x96.mlir
@@ -1,5 +1,4 @@
 // RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN:            -pre-bufferization \
 // RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
 // RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
 // RUN:            -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func | \
@@ -25,3 +24,4 @@ func.func @entry(%A: tensor<64x96xf32>, %B: tensor<96x48xf32>,
   return %D : tensor<64x48xf32>
 }
 // CHECK-COUNT-64: ( 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97 )
+

--- a/test/Benchmarks/matmul_kernel_64x64x64.mlir
+++ b/test/Benchmarks/matmul_kernel_64x64x64.mlir
@@ -1,5 +1,4 @@
 // RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN:            -pre-bufferization \
 // RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
 // RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
 // RUN:            -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func | \
@@ -25,3 +24,4 @@ func.func @entry(%A: tensor<64x64xf32>, %B: tensor<64x64xf32>,
   return %D : tensor<64x64xf32>
 }
 // CHECK-COUNT-64: ( 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65 )
+

--- a/test/Benchmarks/matmul_kernel_64x64x64.mlir
+++ b/test/Benchmarks/matmul_kernel_64x64x64.mlir
@@ -1,0 +1,27 @@
+// RUN: tpp-opt %s -map-linalg-to-tpp \
+// RUN:            -pre-bufferization \
+// RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
+// RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
+// RUN:            -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm -loop-invariant-code-motion -convert-xsmm-to-func | \
+// RUN: tpp-run \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
+// RUN: FileCheck %s
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+
+func.func @entry(%A: tensor<64x64xf32>, %B: tensor<64x64xf32>,
+                  %C: tensor<64x64xf32>) -> tensor<64x64xf32> {
+  %D = linalg.generic {indexing_maps = [#map0, #map1, #map2],
+                         iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%A, %B: tensor<64x64xf32>, tensor<64x64xf32>) outs(%C: tensor<64x64xf32>) {
+      ^bb0(%a: f32, %b: f32, %c: f32):
+        %0 = arith.mulf %a, %b : f32
+        %1 = arith.addf %c, %0 : f32
+        linalg.yield %1 : f32
+    } -> tensor<64x64xf32>
+  return %D : tensor<64x64xf32>
+}
+// CHECK-COUNT-64: ( 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65 )

--- a/test/Benchmarks/mlp_kernel.mlir
+++ b/test/Benchmarks/mlp_kernel.mlir
@@ -1,0 +1,42 @@
+// RUN: tpp-opt %s -map-linalg-to-tpp \
+// RUN:            -main-closure -pre-bufferization -pack-matmul="block-factors=2,2" -loop-invariant-code-motion -canonicalize -undo-main-closure \
+// RUN:            -tile-consumer-and-fuse-producers="tile-sizes=1,0,0,0" -canonicalize -tile-consumer-and-fuse-producers="tile-sizes=1,0,0" -canonicalize \
+// RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" -canonicalize \
+// RUN:            -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
+// RUN:            -map-linalg-to-tpp -convert-linalg-to-tpp="use-parallel-loops=false" -map-to-brgemm -convert-linalg-to-tpp -convert-tpp-to-xsmm \
+// RUN:            -loop-invariant-code-motion -convert-xsmm-to-func | \
+// RUN: tpp-run \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
+// RUN: FileCheck %s
+
+#map0 = affine_map<(d0, d1) -> (0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map3 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map4 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module @predict_function  {
+  func.func @entry(%arg0: tensor<4x8xf32>,
+                  %arg1: tensor<8x16xf32> {stdx.const},
+                  %arg2: tensor<1x16xf32> {stdx.const},
+                  %output: tensor<4x16xf32> {stdx.res}) -> tensor<4x16xf32> {
+    %1 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%arg2 : tensor<1x16xf32>) outs(%output : tensor<4x16xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      linalg.yield %arg9 : f32
+    } -> tensor<4x16xf32>
+    %2 = linalg.generic {indexing_maps = [#map2, #map3, #map4], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : tensor<4x8xf32>, tensor<8x16xf32>) outs(%1 : tensor<4x16xf32>) attrs =  {iterator_ranges = [4, 16, 8]} {
+    ^bb0(%arg9: f32, %arg10: f32, %arg11: f32):
+      %16 = arith.mulf %arg9, %arg10 : f32
+      %17 = arith.addf %arg11, %16 : f32
+      linalg.yield %17 : f32
+    } -> tensor<4x16xf32>
+    %c0 = arith.constant 0.0 : f32
+    %3 = linalg.generic {indexing_maps = [#map1, #map1], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<4x16xf32>) outs(%output : tensor<4x16xf32>) {
+    ^bb0(%arg9: f32, %arg10: f32):
+      %16 = arith.maxf %arg9, %c0 : f32
+      linalg.yield %16 : f32
+    } -> tensor<4x16xf32>
+    return %3 : tensor<4x16xf32>
+  }
+}
+// CHECK-COUNT-4: ( 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 )

--- a/test/Benchmarks/mlp_kernel.mlir
+++ b/test/Benchmarks/mlp_kernel.mlir
@@ -1,5 +1,5 @@
 // RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN:            -main-closure -pre-bufferization -pack-matmul="block-factors=2,2" -loop-invariant-code-motion -canonicalize -undo-main-closure \
+// RUN:            -pre-bufferization -pack-matmul="block-factors=2,2" -canonicalize \
 // RUN:            -tile-consumer-and-fuse-producers="tile-sizes=1,0,0,0" -canonicalize -tile-consumer-and-fuse-producers="tile-sizes=1,0,0" -canonicalize \
 // RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" -canonicalize \
 // RUN:            -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
@@ -40,3 +40,4 @@ module @predict_function  {
   }
 }
 // CHECK-COUNT-4: ( 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 )
+

--- a/test/Benchmarks/simple-gemm.mlir
+++ b/test/Benchmarks/simple-gemm.mlir
@@ -1,0 +1,29 @@
+// RUN: tpp-opt %s -map-linalg-to-tpp \
+// RUN:            -pre-bufferization \
+// RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
+// RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
+// RUN:            -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func | \
+// RUN: tpp-run \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
+// RUN: FileCheck %s
+
+#map0 = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+
+ func.func @entry(%A: tensor<4x8xf32>,
+          %B: tensor<8x4xf32>, %C: tensor<4x4xf32> {linalg.inplaceable = true}) -> tensor<4x4xf32> {
+    %D = linalg.generic {indexing_maps = [#map0, #map1, #map2],
+                         iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%A, %B: tensor<4x8xf32>, tensor<8x4xf32>) outs(%C: tensor<4x4xf32>) {
+      ^bb0(%a: f32, %b: f32, %c: f32):
+        %0 = arith.mulf %a, %b : f32
+        %1 = arith.addf %c, %0 : f32
+        linalg.yield %1 : f32
+    } -> tensor<4x4xf32>
+    return %D : tensor<4x4xf32>
+  }
+}
+// CHECK-COUNT-4: ( 9, 9, 9, 9 )

--- a/test/Benchmarks/simple-gemm.mlir
+++ b/test/Benchmarks/simple-gemm.mlir
@@ -1,5 +1,4 @@
 // RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN:            -pre-bufferization \
 // RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
 // RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
 // RUN:            -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func | \
@@ -27,3 +26,4 @@ module {
   }
 }
 // CHECK-COUNT-4: ( 9, 9, 9, 9 )
+

--- a/test/Benchmarks/simple_copy.mlir
+++ b/test/Benchmarks/simple_copy.mlir
@@ -1,0 +1,23 @@
+// RUN: tpp-opt %s -map-linalg-to-tpp \
+// RUN:            -pre-bufferization \
+// RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
+// RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
+// RUN:            -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func | \
+// RUN: tpp-run \
+// RUN:  -e entry -entry-point-result=void  \
+// RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
+// RUN: FileCheck %s
+
+#map0 = affine_map<(d0, d1) -> (d0, d1)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func @entry(%I: tensor<6x9xf32>, %O: tensor<6x9xf32>) -> tensor<6x9xf32> {
+  %OO = linalg.generic {indexing_maps = [#map0, #map1],
+                        iterator_types = ["parallel", "parallel"]}
+    ins(%I: tensor<6x9xf32>) outs(%O: tensor<6x9xf32>) {
+      ^bb0(%i: f32, %o:f32):
+        linalg.yield %i: f32
+    } -> tensor<6x9xf32>
+  return %OO: tensor<6x9xf32>
+}
+// CHECK-COUNT-1: ( 1, 1, 1, 1, 1, 1, 1, 1, 1 )

--- a/test/Benchmarks/simple_copy.mlir
+++ b/test/Benchmarks/simple_copy.mlir
@@ -1,5 +1,4 @@
 // RUN: tpp-opt %s -map-linalg-to-tpp \
-// RUN:            -pre-bufferization \
 // RUN:            -one-shot-bufferize="bufferize-function-boundaries allow-return-allocs function-boundary-type-conversion=identity-layout-map" \
 // RUN:            -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
 // RUN:            -convert-linalg-to-tpp -convert-tpp-to-xsmm -convert-xsmm-to-func | \
@@ -21,3 +20,4 @@ func.func @entry(%I: tensor<6x9xf32>, %O: tensor<6x9xf32>) -> tensor<6x9xf32> {
   return %OO: tensor<6x9xf32>
 }
 // CHECK-COUNT-1: ( 1, 1, 1, 1, 1, 1, 1, 1, 1 )
+

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -242,11 +242,13 @@ static LogicalResult prepareMLIRKernel(Operation *op) {
   APFloat vectorFloatValue = APFloat(-1.0F);
   auto minusOne = builder.create<arith::ConstantFloatOp>(loc, vectorFloatValue,
                                                          builder.getF32Type());
-  auto zeroIdx = builder.create<arith::ConstantIndexOp>(loc, 0);
-  auto indices = ValueRange{zeroIdx, zeroIdx};
   // TODO: Create a loop in IR
+  auto zeroIdx = builder.create<arith::ConstantIndexOp>(loc, 0);
   assert(outerDims.size() == 1 && "Only supports 2D tensors for now");
   for (int i = 0; i < outerDims[0]; i++) {
+    auto beginIdx = builder.create<arith::ConstantIndexOp>(loc, i);
+
+    auto indices = ValueRange{beginIdx, zeroIdx};
     auto vector = builder.create<vector::TransferReadOp>(loc, vecType, result,
                                                          indices, minusOne);
     builder.create<vector::PrintOp>(loc, vector);

--- a/tpp-run/tpp-run.cpp
+++ b/tpp-run/tpp-run.cpp
@@ -228,11 +228,11 @@ static LogicalResult prepareMLIRKernel(Operation *op) {
   assert(outputType && "Unsupported return type");
   VectorType vecType;
   auto lastDim = outputType.getRank() - 1;
-  ArrayRef<int64_t> outer_dims(1);
+  ArrayRef<int64_t> outerDims(1);
   if (outputType.getRank() > 1) {
-    ArrayRef<int64_t> inner_dims(&outputType.getShape()[lastDim], 1);
-    vecType = VectorType::get(inner_dims, outputType.getElementType());
-    outer_dims =
+    ArrayRef<int64_t> innerDims(&outputType.getShape()[lastDim], 1);
+    vecType = VectorType::get(innerDims, outputType.getElementType());
+    outerDims =
         ArrayRef<int64_t>(&outputType.getShape()[0], outputType.getRank() - 1);
   } else {
     vecType =
@@ -245,8 +245,8 @@ static LogicalResult prepareMLIRKernel(Operation *op) {
   auto zeroIdx = builder.create<arith::ConstantIndexOp>(loc, 0);
   auto indices = ValueRange{zeroIdx, zeroIdx};
   // TODO: Create a loop in IR
-  assert(outer_dims.size() == 1 && "Only supports 2D tensors for now");
-  for (int i = 0; i < outer_dims[0]; i++) {
+  assert(outerDims.size() == 1 && "Only supports 2D tensors for now");
+  for (int i = 0; i < outerDims[0]; i++) {
     auto vector = builder.create<vector::TransferReadOp>(loc, vecType, result,
                                                          indices, minusOne);
     builder.create<vector::PrintOp>(loc, vector);


### PR DESCRIPTION
Adding the benchmarks as tests using the new tpp-run infrastructure.

This allows us to test them at pre-merge checks and only benchmark them on post-merge checks, after building an infrastructure to run these tests through a harness.

Once these tests can be run as benchmarks, we can remove the old benchmark harness that is too complicated and doesn't scale.

A future commit will add the benchmarking harness.

Two changes to tpp-run:
 * Don't try to allocate a vector for the entire tensor, this leads to stack overflow. For now we loop a 2D tensor with a 1D vector. We should really create code that dynamically determines the rank, etc.
 * Changed to non-constant globals, so we can write to them on the kernel and get the updated values to print afterwards.

Continue working towards #74.