### PR TITLE
Split-input-file changes the map names

### DIFF
--- a/test/TPP/linalg-to-tpp.mlir
+++ b/test/TPP/linalg-to-tpp.mlir
@@ -23,7 +23,7 @@ func.func @relu(%arg3: memref<64x32x32xf32>) -> memref<64x32x32xf32> {
   // CHECK-DAG: %[[sixtyfour:.*]] = arith.constant 64 : index
   // CHECK: scf.parallel ([[i:.*]]) = (%[[zero]]) to (%[[sixtyfour]]) step (%[[one]]) {
   // CHECK: %[[slice:.*]] = memref.subview
-  // CHECK: tpp.relu out(%[[slice]] : memref<32x32xf32, #map>)
+  // CHECK: tpp.relu out(%[[slice]] : memref<32x32xf32, #map{{.*}}>)
   // CHECK: scf.yield
   %c0 = arith.constant 0.0 : f32
   linalg.generic {


### PR DESCRIPTION
We may have this issue in other tests, but this is something that was failing locally.

Because of the split input file flag, the map names are scrambled and new maps show up in each split, so we can't really tell what is the name that will happen to be, especially as we change other parts of the file.