### PR TITLE
Fix ConvertLinalgToTpp member self initialization

### DIFF
--- a/lib/TPP/ConvertLinalgToTpp.cpp
+++ b/lib/TPP/ConvertLinalgToTpp.cpp
@@ -444,7 +444,7 @@ struct ConvertLinalgToTpp : public ConvertLinalgToTppBase<ConvertLinalgToTpp> {
   ConvertLinalgToTpp() = default;
   ConvertLinalgToTpp(bool enabledPreconditions, bool useParallelLoops,
                      ArrayRef<int64_t> tileSizes) {
-    this->enableTiling = enableTiling;
+    this->enableTiling = enabledPreconditions;
     this->useParallelLoops = useParallelLoops;
     this->tileSizes = tileSizes;
   }


### PR DESCRIPTION
Noticed due to this warning:
`../lib/TPP/ConvertLinalgToTpp.cpp:447:26: warning: implicitly-declared ‘mlir::Pass::Option<bool>& mlir::Pass::Option<bool>::operator=(const mlir::Pass::Option<bool>&)’ is deprecated [-Wdeprecated-copy]
  447 |     this->enableTiling = enableTiling;`