### PR TITLE
Add `Reshape2dOp` and `CollapseTo2dOp`

### DIFF
--- a/include/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
+++ b/include/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
@@ -216,6 +216,7 @@ def MapLinalgToTppOp : Op<Transform_Dialect, "structured.map_linalg_to_tpp", [
 //===----------------------------------------------------------------------===//
 
 // TODO: this does not compose as it invalidate all the handles.
+// TODO: retire this and use `CollapseTo2dOp`.
 def FoldUnitExtentDimsOp : Op<Transform_Dialect, "structured.fold_unit_extent_dims", [
     FunctionalStyleTransformOpTrait,
     MemoryEffectsOpInterface,
@@ -313,6 +314,71 @@ def MapAndConvertLinalgToTpp : Op<Transform_Dialect,
         ::mlir::Operation *target,
         ::llvm::SmallVector<::mlir::Operation *> &results,
         ::mlir::transform::TransformState &state);
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Reshape2dOp
+//===----------------------------------------------------------------------===//
+
+def Reshape2dOp : Op<Transform_Dialect, "structured.reshape_2d", [
+    FunctionalStyleTransformOpTrait,
+    MemoryEffectsOpInterface,
+    TransformEachOpTrait,
+    TransformOpInterface]> {
+
+  let description = [{
+    Given a linalg.generic operaiton reshape it as a 2-dimensional operation by
+    tiling out all but the two innermost loops. Only the handle to the tiled
+    operation is returned. use_parallel_loops allows to materialize parallel
+    loops (at the memref abstraction) if the loop is parallel.
+  }];
+
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<BoolAttr, "false">:$use_parallel_loops);
+  let results = (outs PDL_Operation:$tiled_linalg_op);
+
+  let assemblyFormat = [{
+     `in` $target attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure apply(
+      ::mlir::transform::TransformResults &transformResults,
+      ::mlir::transform::TransformState &state); 
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// CollapseTo2dOp
+//===----------------------------------------------------------------------===//
+
+def CollapseTo2dOp : Op<Transform_Dialect, "structured.collapse_to_2d", [
+    FunctionalStyleTransformOpTrait,
+    MemoryEffectsOpInterface,
+    TransformEachOpTrait,
+    TransformOpInterface]> {
+
+  let description = [{
+    Given a linalg.generic operation make it a 2-dimensional by collapsing
+    outer dimensions.
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$collapsed_linalg_op);
+
+  let assemblyFormat = [{
+     `in` $target attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure apply(
+      ::mlir::transform::TransformResults &transformResults,
+      ::mlir::transform::TransformState &state); 
+
+    // Get reassociation for 2d collapsing.
+    SmallVector<ReassociationIndices, 4> 
+      getReassociationIndices(linalg::GenericOp linalgOp);
   }];
 }
 

--- a/include/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
+++ b/include/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.td
@@ -318,7 +318,7 @@ def MapAndConvertLinalgToTpp : Op<Transform_Dialect,
 }
 
 //===----------------------------------------------------------------------===//
-// Reshape2dOp
+// Reshape2DOp
 //===----------------------------------------------------------------------===//
 
 def Reshape2dOp : Op<Transform_Dialect, "structured.reshape_2d", [
@@ -328,7 +328,7 @@ def Reshape2dOp : Op<Transform_Dialect, "structured.reshape_2d", [
     TransformOpInterface]> {
 
   let description = [{
-    Given a linalg.generic operaiton reshape it as a 2-dimensional operation by
+    Given a linalg.generic operation reshape it as a 2-dimensional operation by
     tiling out all but the two innermost loops. Only the handle to the tiled
     operation is returned. use_parallel_loops allows to materialize parallel
     loops (at the memref abstraction) if the loop is parallel.

--- a/lib/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.cpp
+++ b/lib/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.cpp
@@ -192,7 +192,7 @@ transform::MapLinalgToTppOp::apply(transform::TransformResults &results,
     linalg::GenericOp currentTarget = dyn_cast_or_null<linalg::GenericOp>(op);
     if (!currentTarget) {
       auto diag = this->emitOpError()
-                  << "Could not map non-generic op to tpp: " << *op << "\n";
+                  << "Cannot map non-generic op to tpp: " << *op << "\n";
       diag.attachNote(op->getLoc()) << "when applied to this op";
       return DiagnosedSilenceableFailure::definiteFailure();
     }
@@ -284,7 +284,7 @@ DiagnosedSilenceableFailure transform::MapAndConvertLinalgToTpp::applyToOne(
 }
 
 //===----------------------------------------------------------------------===//
-// CollapseTo2dOp
+// CollapseTo2DOp
 //===----------------------------------------------------------------------===//
 
 DiagnosedSilenceableFailure
@@ -296,7 +296,7 @@ transform::CollapseTo2dOp::apply(transform::TransformResults &results,
     linalg::GenericOp currentTarget = dyn_cast_or_null<linalg::GenericOp>(op);
     if (!currentTarget) {
       auto diag = this->emitOpError()
-                  << "Could not collapse non-generic: " << *op << "\n";
+                  << "Cannot collapse non-generic: " << *op << "\n";
       diag.attachNote(op->getLoc()) << "when applied to this op";
       return DiagnosedSilenceableFailure::definiteFailure();
     }
@@ -361,7 +361,7 @@ transform::Reshape2dOp::apply(transform::TransformResults &results,
     linalg::GenericOp currentTarget = dyn_cast_or_null<linalg::GenericOp>(op);
     if (!currentTarget) {
       auto diag = this->emitOpError()
-                  << "Could not reshape non-generic: " << *op << "\n";
+                  << "Cannot not reshape non-generic: " << *op << "\n";
       diag.attachNote(op->getLoc()) << "when applied to this op";
       return DiagnosedSilenceableFailure::definiteFailure();
     }

--- a/lib/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.cpp
+++ b/lib/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.cpp
@@ -10,6 +10,7 @@
 #include "TPP/Dialect/LinalgX/LinalgXOps.h"
 #include "TPP/Transforms.h"
 #include "mlir/AsmParser/AsmParser.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
@@ -279,6 +280,119 @@ DiagnosedSilenceableFailure transform::MapAndConvertLinalgToTpp::applyToOne(
   if (failed(applyPatternsAndFoldGreedily(target, std::move(patterns))))
     return DiagnosedSilenceableFailure(reportUnknownTransformError(target));
 
+  return DiagnosedSilenceableFailure(success());
+}
+
+//===----------------------------------------------------------------------===//
+// CollapseTo2dOp
+//===----------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+transform::CollapseTo2dOp::apply(transform::TransformResults &results,
+                                 transform::TransformState &state) {
+  SmallVector<Operation *> collapsed;
+  ArrayRef<Operation *> payloadOps = state.getPayloadOps(getTarget());
+  for (Operation *op : payloadOps) {
+    linalg::GenericOp currentTarget = dyn_cast_or_null<linalg::GenericOp>(op);
+    if (!currentTarget) {
+      auto diag = this->emitOpError()
+                  << "Could not collapse non-generic: " << *op << "\n";
+      diag.attachNote(op->getLoc()) << "when applied to this op";
+      return DiagnosedSilenceableFailure::definiteFailure();
+    }
+    SimpleRewriter rewriter(currentTarget->getContext());
+    rewriter.setInsertionPoint(currentTarget);
+    FailureOr<linalg::GenericOp> collapsedOp = mlir::linalgx::collapseIterators(
+        rewriter, currentTarget, getReassociationIndices(currentTarget));
+    if (failed(collapsedOp))
+      return DiagnosedSilenceableFailure::definiteFailure();
+    collapsed.append(1, *collapsedOp);
+  }
+  results.set(getCollapsedLinalgOp().cast<OpResult>(), collapsed);
+  return DiagnosedSilenceableFailure(success());
+}
+
+SmallVector<ReassociationIndices, 4>
+transform::CollapseTo2dOp::getReassociationIndices(linalg::GenericOp linalgOp) {
+  SmallVector<ReassociationIndices, 4> reassociationIndices;
+  int64_t numLoops = linalgOp.getNumLoops();
+  int64_t outerLoop = 0;
+  SmallVector<int64_t, 2> outerReassociation;
+  while (outerLoop <= numLoops - 2) {
+    outerReassociation.push_back(outerLoop++);
+  }
+  reassociationIndices.push_back(outerReassociation);
+  while (outerLoop < numLoops) {
+    reassociationIndices.push_back({outerLoop++});
+  }
+  return reassociationIndices;
+}
+
+//===----------------------------------------------------------------------===//
+// Reshape2dOp
+//===----------------------------------------------------------------------===//
+
+// Tiling function to remove all but the zero and first dimension.
+// Tile of zero means no tiling on this dimension. The other
+// dimensions are materialized as loops by tiling with a factor
+// of 1.
+static SmallVector<Value, 4> getTileSizes(OpBuilder &builder,
+                                          linalg::LinalgOp linalgOp) {
+  SmallVector<Value, 4> tppTiles;
+  size_t numberOfLoops = linalgOp.getNumLoops();
+  for (size_t i = 0; i < numberOfLoops; i++)
+    tppTiles.push_back(
+        builder.createOrFold<arith::ConstantIndexOp>(linalgOp.getLoc(), 1));
+  Value zeroVal =
+      builder.createOrFold<arith::ConstantIndexOp>(linalgOp.getLoc(), 0);
+  tppTiles[numberOfLoops - 1] = zeroVal;
+  tppTiles[numberOfLoops - 2] = zeroVal;
+  return tppTiles;
+}
+
+DiagnosedSilenceableFailure
+transform::Reshape2dOp::apply(transform::TransformResults &results,
+                              transform::TransformState &state) {
+  bool useParallelLoops = getUseParallelLoops();
+
+  SmallVector<Operation *> tiled;
+  ArrayRef<Operation *> payloadOps = state.getPayloadOps(getTarget());
+  for (Operation *op : payloadOps) {
+    linalg::GenericOp currentTarget = dyn_cast_or_null<linalg::GenericOp>(op);
+    if (!currentTarget) {
+      auto diag = this->emitOpError()
+                  << "Could not reshape non-generic: " << *op << "\n";
+      diag.attachNote(op->getLoc()) << "when applied to this op";
+      return DiagnosedSilenceableFailure::definiteFailure();
+    }
+    if (currentTarget.getNumLoops() <= 2) {
+      DiagnosedSilenceableFailure diag =
+          emitSilenceableError() << "Expect at least two loops:" << *op << "\n";
+      diag.attachNote(currentTarget->getLoc()) << "when applied to this op";
+      results.set(getResult().cast<OpResult>(), {});
+      return diag;
+    }
+
+    linalg::LinalgTilingOptions linalgTilingOptions;
+    linalg::LinalgTilingLoopType loopsTypes =
+        (useParallelLoops) ? linalg::LinalgTilingLoopType::ParallelLoops
+                           : linalg::LinalgTilingLoopType::Loops;
+    linalgTilingOptions.setLoopType(loopsTypes)
+        .setTileSizeComputationFunction(getTileSizes);
+    SimpleRewriter rewriter(currentTarget->getContext());
+    FailureOr<linalg::TiledLinalgOp> tiledOp =
+        linalg::tileLinalgOp(rewriter, currentTarget, linalgTilingOptions);
+    if (failed(tiledOp))
+      return DiagnosedSilenceableFailure::definiteFailure();
+
+    if (currentTarget.hasBufferSemantics())
+      rewriter.eraseOp(currentTarget);
+    else
+      rewriter.replaceOp(currentTarget, tiledOp->tensorResults);
+
+    tiled.append(1, tiledOp->op);
+  }
+  results.set(getTiledLinalgOp().cast<OpResult>(), tiled);
   return DiagnosedSilenceableFailure(success());
 }
 

--- a/lib/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.cpp
+++ b/lib/TPP/Dialect/LinalgX/TransformOps/LinalgXTransformOps.cpp
@@ -361,7 +361,7 @@ transform::Reshape2dOp::apply(transform::TransformResults &results,
     linalg::GenericOp currentTarget = dyn_cast_or_null<linalg::GenericOp>(op);
     if (!currentTarget) {
       auto diag = this->emitOpError()
-                  << "Cannot not reshape non-generic: " << *op << "\n";
+                  << "Cannot reshape non-generic: " << *op << "\n";
       diag.attachNote(op->getLoc()) << "when applied to this op";
       return DiagnosedSilenceableFailure::definiteFailure();
     }

--- a/test/TPP/transform/transform-collapse2d.mlir
+++ b/test/TPP/transform/transform-collapse2d.mlir
@@ -36,10 +36,9 @@ func.func @additions(%arg0: memref<2x5x6xf32>, %arg1: memref<2x5x6xf32>) -> memr
 // CHECK: #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
 // CHECK: func.func @additions(
 // CHECK:  %[[ARG0:.+]]: memref<2x5x6xf32>, %[[ARG1:.+]]: memref<2x5x6xf32>) -> memref<2x5x6xf32> {
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
-// CEHCK-DAG: %[[C0:.+]] = arith.constant 0 : index
 // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
-
 // CHECK: scf.for %[[ARG2:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
 // CHECK: %[[SUB:.+]] = memref.subview %[[ARG0]][%[[ARG2]], 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
 // CHECK: %[[SUB1:.+]] = memref.subview %[[ARG1]][%[[ARG2]], 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
@@ -47,7 +46,6 @@ func.func @additions(%arg0: memref<2x5x6xf32>, %arg1: memref<2x5x6xf32>) -> memr
 // CHECK: %[[COLLAPSE1:.+]] = memref.collapse_shape %[[SUB1]] {{\[}}[0, 1], [2]] : memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>> into memref<5x6xf32, strided<[6, 1], offset: ?>>
 // CHECK: linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]]], iterator_types = ["parallel", "parallel"]} ins(%[[COLLAPSE]] : memref<5x6xf32, strided<[6, 1], offset: ?>>) outs(%[[COLLAPSE1]] : memref<5x6xf32, strided<[6, 1], offset: ?>>
 // CHECK: }
-
 // CHECK: scf.for %[[ARG3:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
 // CHECK: %[[SUB2:.+]] = memref.subview %[[ARG0]][%[[ARG3]], 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
 // CHECK: %[[SUB3:.+]] = memref.subview %[[ARG1]][%[[ARG3]], 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>

--- a/test/TPP/transform/transform-collapse2d.mlir
+++ b/test/TPP/transform/transform-collapse2d.mlir
@@ -1,0 +1,55 @@
+// RUN: tpp-opt %s -transform-dialect-interpreter -canonicalize | FileCheck %s
+
+transform.sequence failures(propagate) {
+  ^bb0(%arg0: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg0
+    %1 = transform.structured.collapse_to_2d in %0
+}
+
+func.func @additions(%arg0: memref<2x5x6xf32>, %arg1: memref<2x5x6xf32>) -> memref<2x5x6xf32> {
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %c2 = arith.constant 2 : index
+  scf.for %arg2 = %c0 to %c2 step %c1 {
+     %subview = memref.subview %arg0[%arg2, 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
+    %subview_0 = memref.subview %arg1[%arg2, 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
+    linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%subview : memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>) outs(%subview_0 : memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>) {
+      ^bb0(%in: f32, %out: f32):
+        %0 = arith.addf %in, %out : f32
+        linalg.yield %0 : f32
+    }
+  }
+  scf.for %arg2 = %c0 to %c2 step %c1 {
+    %subview = memref.subview %arg0[%arg2, 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
+    %subview_0 = memref.subview %arg1[%arg2, 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
+    linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel", "parallel"]} ins(%subview : memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>) outs(%subview_0 : memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>) {
+      ^bb0(%in: f32, %out: f32):
+        %0 = arith.addf %in, %out : f32
+        linalg.yield %0 : f32
+    }
+  }
+  return %arg1 : memref<2x5x6xf32>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK: func.func @additions(
+// CHECK:  %[[ARG0:.+]]: memref<2x5x6xf32>, %[[ARG1:.+]]: memref<2x5x6xf32>) -> memref<2x5x6xf32> {
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CEHCK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+
+// CHECK: scf.for %[[ARG2:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK: %[[SUB:.+]] = memref.subview %[[ARG0]][%[[ARG2]], 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
+// CHECK: %[[SUB1:.+]] = memref.subview %[[ARG1]][%[[ARG2]], 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
+// CHECK: %[[COLLAPSE:.+]] = memref.collapse_shape %[[SUB]] {{\[}}[0, 1], [2]] : memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>> into memref<5x6xf32, strided<[6, 1], offset: ?>>
+// CHECK: %[[COLLAPSE1:.+]] = memref.collapse_shape %[[SUB1]] {{\[}}[0, 1], [2]] : memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>> into memref<5x6xf32, strided<[6, 1], offset: ?>>
+// CHECK: linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]]], iterator_types = ["parallel", "parallel"]} ins(%[[COLLAPSE]] : memref<5x6xf32, strided<[6, 1], offset: ?>>) outs(%[[COLLAPSE1]] : memref<5x6xf32, strided<[6, 1], offset: ?>>
+// CHECK: }
+
+// CHECK: scf.for %[[ARG3:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK: %[[SUB2:.+]] = memref.subview %[[ARG0]][%[[ARG3]], 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
+// CHECK: %[[SUB3:.+]] = memref.subview %[[ARG1]][%[[ARG3]], 0, 0] [1, 5, 6] [1, 1, 1] : memref<2x5x6xf32> to memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>>
+// CHECK: %[[COLLAPSE2:.+]] = memref.collapse_shape %[[SUB2]] {{\[}}[0, 1], [2]] : memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>> into memref<5x6xf32, strided<[6, 1], offset: ?>>
+// CHECK: %[[COLLAPSE3:.+]] = memref.collapse_shape %[[SUB3]] {{\[}}[0, 1], [2]] : memref<1x5x6xf32, strided<[30, 6, 1], offset: ?>> into memref<5x6xf32, strided<[6, 1], offset: ?>>
+// CHECK: linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]]], iterator_types = ["parallel", "parallel"]} ins(%[[COLLAPSE2]] : memref<5x6xf32, strided<[6, 1], offset: ?>>) outs(%[[COLLAPSE3]] : memref<5x6xf32, strided<[6, 1], offset: ?>>
+// CHECK: }

--- a/test/TPP/transform/transform-collapse2d.mlir
+++ b/test/TPP/transform/transform-collapse2d.mlir
@@ -6,6 +6,8 @@ transform.sequence failures(propagate) {
     %1 = transform.structured.collapse_to_2d in %0
 }
 
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+
 func.func @additions(%arg0: memref<2x5x6xf32>, %arg1: memref<2x5x6xf32>) -> memref<2x5x6xf32> {
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index

--- a/test/TPP/transform/transform-map-linalg-to-tpp.mlir
+++ b/test/TPP/transform/transform-map-linalg-to-tpp.mlir
@@ -8,7 +8,7 @@
 transform.sequence failures(propagate) {
   ^bb0(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["func.func"]} in %arg1
-    // expected-error @below {{Could not map non-generic op to tpp}}
+    // expected-error @below {{Cannot map non-generic op to tpp}}
     %1 = transform.structured.map_linalg_to_tpp in %0
 }
 

--- a/test/TPP/transform/transform-reshape2d.mlir
+++ b/test/TPP/transform/transform-reshape2d.mlir
@@ -1,0 +1,147 @@
+// RUN: tpp-opt %s -transform-dialect-interpreter -canonicalize -split-input-file -verify-diagnostics | FileCheck %s
+
+transform.sequence failures(propagate) {
+  ^bb0(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
+    %1 = transform.structured.reshape_2d in %0
+}
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+func.func @add(%arg0: memref<5x5x4xf32>, %arg1: memref<5x5x4xf32>) -> memref<5x5x4xf32> {
+  linalg.generic {
+    indexing_maps = [#map, #map],
+    iterator_types = ["parallel", "parallel", "parallel"]}
+    ins(%arg0: memref<5x5x4xf32>) outs(%arg1: memref<5x5x4xf32>) {
+      ^bb0(%arg2: f32, %arg3: f32):
+        %1 = arith.addf %arg2, %arg3 : f32
+        linalg.yield %1 : f32
+  }
+  return %arg1: memref<5x5x4xf32>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK: func.func @add(
+// CHECK-SAME: %[[ARG0:.+]]: memref<5x5x4xf32>, %[[ARG1:.+]]: memref<5x5x4xf32>) -> memref<5x5x4xf32> {
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C5:.+]] = arith.constant 5 : index
+// CHECK: scf.for %[[ARG2:.+]] = %[[C0]] to %[[C5]] step %[[C1]] {
+// CHECK: %[[SUB:.+]] = memref.subview %[[ARG0]][%[[ARG2]], 0, 0] [1, 5, 4] [1, 1, 1] : memref<5x5x4xf32> to memref<1x5x4xf32, strided<[20, 4, 1], offset: ?>>
+// CHECK: %[[SUB0:.+]] = memref.subview %[[ARG1]][%[[ARG2]], 0, 0] [1, 5, 4] [1, 1, 1] : memref<5x5x4xf32> to memref<1x5x4xf32, strided<[20, 4, 1], offset: ?>>
+// CHECK: linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]]], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[SUB]] : memref<1x5x4xf32, strided<[20, 4, 1], offset: ?>>) outs(%[[SUB0]] : memref<1x5x4xf32, strided<[20, 4, 1], offset: ?>>)
+// CHECK: return %[[ARG1]] : memref<5x5x4xf32>
+// CHECK: }
+
+// -----
+
+transform.sequence failures(propagate) {
+  ^bb0(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
+    %1 = transform.structured.reshape_2d in %0
+}
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+func.func @add(%arg0: tensor<5x5x4xf32>, %arg1: tensor<5x5x4xf32>) -> tensor<5x5x4xf32> {
+  %0 = linalg.generic { indexing_maps = [#map, #map], 
+                        iterator_types = ["parallel", "parallel", "parallel"]}
+    ins(%arg0: tensor<5x5x4xf32>) outs(%arg1: tensor<5x5x4xf32>) {
+      ^bb0(%arg2: f32, %arg3: f32):
+        %1 = arith.addf %arg2, %arg3 : f32
+        linalg.yield %1 : f32
+  } -> tensor<5x5x4xf32>     
+  return %0: tensor<5x5x4xf32>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK: func.func @add(
+// CHECK-SAME: %[[ARG0:.+]]: tensor<5x5x4xf32>, %[[ARG1:.+]]: tensor<5x5x4xf32>) -> tensor<5x5x4xf32> {
+// CHECK: %[[LOOP:.+]] = scf.for %[[ARG2:.+]] = %[[C0]] to %[[C5]] step %[[C1]] iter_args(%[[ARG3:.+]] = %[[ARG1]]) -> (tensor<5x5x4xf32>) {
+// CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], 0, 0] [1, 5, 4] [1, 1, 1] : tensor<5x5x4xf32> to tensor<1x5x4xf32>
+// CHECK: %[[SLICE0:.+]] = tensor.extract_slice %[[ARG3]][%[[ARG2]], 0, 0] [1, 5, 4] [1, 1, 1] : tensor<5x5x4xf32> to tensor<1x5x4xf32>
+// CHECK: %[[ADD:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]]], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[SLICE]] : tensor<1x5x4xf32>) outs(%[[SLICE0]] : tensor<1x5x4xf32>)
+// CHECK: %[[INSERT:.+]] = tensor.insert_slice %[[ADD]] into %[[ARG3]][%[[ARG2]], 0, 0] [1, 5, 4] [1, 1, 1] : tensor<1x5x4xf32> into tensor<5x5x4xf32>
+// CHECK: scf.yield %[[INSERT]] : tensor<5x5x4xf32>
+// CHECK: }
+// CHECK: return %[[LOOP]] : tensor<5x5x4xf32>
+// CHECK: }
+
+// -----
+
+// Expect to fail, as we have a single loop
+transform.sequence failures(propagate) {
+  ^bb0(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
+    // expected-error @below {{Expect at least two loops:}}
+    %1 = transform.structured.reshape_2d in %0
+}
+
+#map = affine_map<(d0) -> (d0)>
+func.func @add(%arg0: tensor<5xf32>, %arg1: tensor<5xf32>) -> tensor<5xf32> {
+  // expected-note @below {{when applied to this op}}
+  %0 = linalg.generic { indexing_maps = [#map, #map], 
+                        iterator_types = ["parallel"]}
+    ins(%arg0: tensor<5xf32>) outs(%arg1: tensor<5xf32>) {
+      ^bb0(%arg2: f32, %arg3: f32):
+        %1 = arith.addf %arg2, %arg3 : f32
+        linalg.yield %1 : f32
+  } -> tensor<5xf32>     
+  return %0: tensor<5xf32>
+}
+
+// -----
+
+// Expect to fail as we handle only generic
+transform.sequence failures(propagate) {
+  ^bb0(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1
+    // expected-error @below {{Could not reshape non-generic:}}
+    %1 = transform.structured.reshape_2d in %0
+}
+
+func.func @block_linalg_matmul(
+  %arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %arg2: tensor<?x?xf32>)
+    -> tensor<?x?xf32> {
+  // expected-note @below {{when applied to this op}}
+  %0 = linalg.matmul  ins(%arg0, %arg1: tensor<?x?xf32>, tensor<?x?xf32>)
+                     outs(%arg2: tensor<?x?xf32>)
+    -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+transform.sequence failures(propagate) {
+  ^bb0(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
+    %1 = transform.structured.reshape_2d in %0
+}
+
+#map = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+func.func @add(%arg0: tensor<?x?x4xf32>, %arg1: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+  %0 = linalg.generic { indexing_maps = [#map, #map],
+                        iterator_types = ["parallel", "parallel", "parallel"]}
+    ins(%arg0: tensor<?x?x4xf32>) outs(%arg1: tensor<?x?x4xf32>) {
+      ^bb0(%arg2: f32, %arg3: f32):
+        %1 = arith.addf %arg2, %arg3 : f32
+        linalg.yield %1 : f32
+  } -> tensor<?x?x4xf32>
+  return %0: tensor<?x?x4xf32>
+}
+
+// CHECK: #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK: func.func @add(
+// CHECK-SAME:  %[[ARG0:.+]]: tensor<?x?x4xf32>, %[[ARG1:.+]]: tensor<?x?x4xf32>) -> tensor<?x?x4xf32> {
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[DIM:.+]] = tensor.dim %[[ARG0]], %[[C0]] : tensor<?x?x4xf32>
+// CHECK: %[[LOOP:.+]] = scf.for %[[ARG2:.+]] = %[[C0]] to %[[DIM]] step %[[C1]] iter_args(%[[ARG3:.+]] = %[[ARG1]]) -> (tensor<?x?x4xf32>) {
+// CHECK: %[[DIM0:.+]] = tensor.dim %[[ARG0]], %[[C1]] : tensor<?x?x4xf32>
+// CHECK-NEXT: %[[DIM1:.+]] = tensor.dim %[[ARG3]], %[[C1]] : tensor<?x?x4xf32>
+// CHECK: %[[SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG2]], 0, 0] [1, %[[DIM0]], 4] [1, 1, 1] : tensor<?x?x4xf32> to tensor<1x?x4xf32>
+// C_HECK: %[[SLICE1:.+]] = tensor.extract_slice %[[ARG3]][%[[ARG2]], 0, 0] [1, %[[DIM1]], 4] [1, 1, 1] : tensor<?x?x4xf32> to tensor<1x?x4xf32>
+// C_HECK: %[[ADD:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP]]], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[SLICE]] : tensor<1x?x4xf32>) outs(%[[SLICE1]] : tensor<1x?x4xf32>)
+// CHECK: %[[INSERT:.+]] = tensor.insert_slice %[[ADD]] into %[[ARG3]][%[[ARG2]], 0, 0] [1, %[[DIM1]], 4] [1, 1, 1] : tensor<1x?x4xf32> into tensor<?x?x4xf32>
+// CHECK: scf.yield %[[INSERT]] : tensor<?x?x4xf32>
+// CHECK: }
+// CHECK: return %[[LOOP]] : tensor<?x?x4xf32>
+// CHECK: }

--- a/test/TPP/transform/transform-reshape2d.mlir
+++ b/test/TPP/transform/transform-reshape2d.mlir
@@ -94,7 +94,7 @@ func.func @add(%arg0: tensor<5xf32>, %arg1: tensor<5xf32>) -> tensor<5xf32> {
 transform.sequence failures(propagate) {
   ^bb0(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1
-    // expected-error @below {{Could not reshape non-generic:}}
+    // expected-error @below {{Cannot reshape non-generic:}}
     %1 = transform.structured.reshape_2d in %0
 }
 


### PR DESCRIPTION
Add some basic blocks operations that will help the transition to a transform optimization pipeline. These ops are needed when mapping and converting from Lianlg to TPP.