### PR TITLE
Fix TPP conversion

### DIFF
--- a/include/TPP/Dialect/Tpp/TppUtils.h
+++ b/include/TPP/Dialect/Tpp/TppUtils.h
@@ -42,7 +42,33 @@ bool hasCopySemantics(linalg::LinalgOp linalgOp);
 bool hasMaxfZeroOp(linalg::LinalgOp linalgOp);
 
 // Returns true if the linalg generic is a tpp.matmul.
+// 1. Buffer semantics.
+// 2. One output and two inputs.
+// 3. A single region with a an add and a mul operation
+// 4. Loops are: [parallel, parallel, reduction]
+// 5. Access pattern is [i, j] -> [i, k] [k, j]
 bool isTppMatmul(linalg::GenericOp linalgOp);
+
+// Returns true if the linalg generic is a tpp.add.
+// 1. Buffer semantics.
+// 2. One output and one input.
+// 3. A single region with an add operation.
+// 4. All loops are parallel and the number of loops is less than or equal to 2.
+bool isTppAdd(linalg::GenericOp linalgOp);
+
+// Returns true if the linalg.generic is a tpp.identity
+// 1. Buffer semantics.
+// 2. One output and one input.
+// 3. A single region with a yield operation.
+// 4. All loops are parallel and the number of loops is less than or equal to 2.
+bool isTppIdentity(linalg::GenericOp linalgOp);
+
+// Returns true if the linalg.generic is a tpp.relu:
+// 1. Buffer semantics.
+// 2. One output and zero input.
+// 3. A single region with a maxf operation.
+// 4. All loops are parallel and the number of loops is less than or equal to 2.
+bool isTppRelu(linalg::GenericOp linalgOp);
 
 // Returns true if the linalg generic can be mapped to a tpp.identity.
 bool canMapToTppIdentity(linalg::GenericOp linalgOp);

--- a/lib/TPP/Dialect/Tpp/TppUtils.cpp
+++ b/lib/TPP/Dialect/Tpp/TppUtils.cpp
@@ -308,6 +308,17 @@ bool canMapToTppAdd(linalg::GenericOp linalgOp) {
   return hasOnlyScalarElementwiseOp<arith::AddFOp>(linalgOp.getRegion());
 }
 
+// TODO: check access pattern using affine map.
+bool isTppAdd(linalg::GenericOp linalgOp) {
+  if (linalgOp.getNumLoops() != linalgOp.getNumParallelLoops())
+    return false;
+  if ((linalgOp.getNumDpsInputs() != 1) || (linalgOp.getNumDpsInits() != 1))
+    return false;
+  if (linalgOp.hasTensorSemantics())
+    return false;
+  return hasOnlyScalarElementwiseOp<arith::AddFOp>(linalgOp.getRegion());
+}
+
 bool canMapToTppRelu(linalg::GenericOp linalgOp) {
   if (!linalg::isElementwise(linalgOp))
     return false;
@@ -316,10 +327,33 @@ bool canMapToTppRelu(linalg::GenericOp linalgOp) {
   return hasOnlyScalarElementwiseOp<arith::MaxFOp>(linalgOp.getRegion());
 }
 
+// TODO: check access pattern using affine map.
+bool isTppRelu(linalg::GenericOp linalgOp) {
+  if (linalgOp.getNumLoops() != linalgOp.getNumParallelLoops())
+    return false;
+  if ((linalgOp.getNumDpsInputs() != 0) || (linalgOp.getNumDpsInits() != 1))
+    return false;
+  if (linalgOp.hasTensorSemantics())
+    return false;
+  return hasOnlyScalarElementwiseOp<arith::MaxFOp>(linalgOp.getRegion());
+}
+
 bool canMapToTppIdentity(linalg::GenericOp linalgOp) {
   if (!linalg::isElementwise(linalgOp))
     return false;
   return (hasStaticShape(linalgOp) && hasCopySemantics(linalgOp));
+}
+
+// TODO: check access pattern using affine map. We need to take into account
+// broadcasting too.
+bool isTppIdentity(linalg::GenericOp linalgOp) {
+  if (linalgOp.getNumLoops() != linalgOp.getNumParallelLoops())
+    return false;
+  if ((linalgOp.getNumDpsInputs() != 1) || (linalgOp.getNumDpsInits() != 1))
+    return false;
+  if (linalgOp.hasTensorSemantics())
+    return false;
+  return hasCopySemantics(linalgOp);
 }
 
 } // namespace utils


### PR DESCRIPTION
We should *not* use annotation for converting linalg to tpp. This is a first patch to untangle the mapping and conversion pass.