### PR TITLE
Benchmark kernels with simple statistics

### DIFF
--- a/test/Benchmarks/matmul_kernel_12x6x9.mlir
+++ b/test/Benchmarks/matmul_kernel_12x6x9.mlir
@@ -3,7 +3,7 @@
 // RUN: -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
 // RUN: -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run -n 2 \
+// RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/matmul_kernel_12x6x9.mlir
+++ b/test/Benchmarks/matmul_kernel_12x6x9.mlir
@@ -3,7 +3,7 @@
 // RUN: -canonicalize -drop-equivalent-buffer-results -finalizing-bufferize \
 // RUN: -convert-linalg-to-tpp="enable-tiling" -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run \
+// RUN: tpp-run -n 2 \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
@@ -20,7 +20,10 @@ func.func @entry(%A: tensor<12x9xf32>, %B: tensor<9x6xf32>,
   %D = linalg.matmul ins(%A, %B: tensor<12x9xf32>, tensor<9x6xf32>) outs(%C: tensor<12x6xf32>) -> tensor<12x6xf32>
   return %D : tensor<12x6xf32>
 }
+// Output
 // CHECK-COUNT-12: ( 10, 10, 10, 10, 10, 10 )
+// Stats
+// CHECK: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
 
 // TPP: func.func @entry(
 // TPP-SAME:  %[[ARG0:.+]]: memref<12x9xf32>,

--- a/test/Benchmarks/matmul_kernel_48x64x96.mlir
+++ b/test/Benchmarks/matmul_kernel_48x64x96.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run -n 2 \
+// RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/matmul_kernel_48x64x96.mlir
+++ b/test/Benchmarks/matmul_kernel_48x64x96.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run \
+// RUN: tpp-run -n 2 \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
@@ -20,7 +20,10 @@ func.func @entry(%A: tensor<48x96xf32>, %B: tensor<96x64xf32>,
   %D = linalg.matmul ins(%A, %B: tensor<48x96xf32>, tensor<96x64xf32>) outs(%C: tensor<48x64xf32>) -> tensor<48x64xf32>
   return %D : tensor<48x64xf32>
 }
+// Output
 // CHECK-COUNT-48: ( 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97 )
+// Stats
+// CHECK: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
 
 // TPP: func.func @entry(
 // TPP-SAME:  %[[ARG0:.+]]: memref<48x96xf32>,

--- a/test/Benchmarks/matmul_kernel_64x48x96.mlir
+++ b/test/Benchmarks/matmul_kernel_64x48x96.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run -n 2 \
+// RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/matmul_kernel_64x48x96.mlir
+++ b/test/Benchmarks/matmul_kernel_64x48x96.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run \
+// RUN: tpp-run -n 2 \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
@@ -20,7 +20,10 @@ func.func @entry(%A: tensor<64x96xf32>, %B: tensor<96x48xf32>,
   %D = linalg.matmul ins(%A, %B: tensor<64x96xf32>, tensor<96x48xf32>) outs(%C: tensor<64x48xf32>) -> tensor<64x48xf32>
   return %D : tensor<64x48xf32>
 }
+// Output
 // CHECK-COUNT-64: ( 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97, 97 )
+// Stats
+// CHECK: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
 
 // TPP: func.func @entry(
 // TPP-SAME:  %[[ARG0:.+]]: memref<64x96xf32>,

--- a/test/Benchmarks/matmul_kernel_64x64x64.mlir
+++ b/test/Benchmarks/matmul_kernel_64x64x64.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run -n 2 \
+// RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/matmul_kernel_64x64x64.mlir
+++ b/test/Benchmarks/matmul_kernel_64x64x64.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run \
+// RUN: tpp-run -n 2 \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
@@ -24,7 +24,10 @@ func.func @entry(%A: tensor<64x64xf32>, %B: tensor<64x64xf32>,
   %D = linalg.matmul ins(%A, %B: tensor<64x64xf32>, tensor<64x64xf32>) outs(%C: tensor<64x64xf32>) -> tensor<64x64xf32>
   return %D : tensor<64x64xf32>
 }
+// Output
 // CHECK-COUNT-64: ( 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65 )
+// Stats
+// CHECK: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
 
 // TPP: func.func @entry(
 // TPP-SAME:  %[[ARG0:.+]]: memref<64x64xf32>, %[[ARG1:.+]]: memref<64x64xf32>, %[[ARG2:.+]]: memref<64x64xf32>)

--- a/test/Benchmarks/mlp_kernel.mlir
+++ b/test/Benchmarks/mlp_kernel.mlir
@@ -4,7 +4,7 @@
 // RUN: -map-linalg-to-tpp -convert-linalg-to-tpp="use-parallel-loops=false" \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run -n 2 \
+// RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/mlp_kernel.mlir
+++ b/test/Benchmarks/mlp_kernel.mlir
@@ -4,7 +4,7 @@
 // RUN: -map-linalg-to-tpp -convert-linalg-to-tpp="use-parallel-loops=false" \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run \
+// RUN: tpp-run -n 2 \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
@@ -34,7 +34,10 @@ func.func @entry(%arg0: tensor<4x8xf32>, %arg1: tensor<8x16xf32>, %arg2: tensor<
   } -> tensor<4x16xf32>
   return %3 : tensor<4x16xf32>
 }
+// Output
 // CHECK-COUNT-4: ( 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9 )
+// Stats
+// CHECK: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
 
 // TPP: func.func @entry(
 // TPP-SAME:  %[[ARG0:.+]]: memref<4x8xf32>,

--- a/test/Benchmarks/simple-gemm.mlir
+++ b/test/Benchmarks/simple-gemm.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run -n 2 \
+// RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/test/Benchmarks/simple-gemm.mlir
+++ b/test/Benchmarks/simple-gemm.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run \
+// RUN: tpp-run -n 2 \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
@@ -21,7 +21,10 @@ func.func @entry(%A: tensor<4x8xf32>,
   return %D : tensor<4x4xf32>
 }
 
+// Output
 // CHECK-COUNT-4: ( 9, 9, 9, 9 )
+// Stats
+// CHECK: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
 
 // TPP: func.func @entry(
 // TPP-SAME:  %[[ARG0:.+]]: memref<4x8xf32>,

--- a/test/Benchmarks/simple_copy.mlir
+++ b/test/Benchmarks/simple_copy.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run \
+// RUN: tpp-run -n 2 \
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s
@@ -27,7 +27,10 @@ func.func @entry(%I: tensor<6x9xf32>, %O: tensor<6x9xf32>) -> tensor<6x9xf32> {
     } -> tensor<6x9xf32>
   return %OO: tensor<6x9xf32>
 }
+// Output
 // CHECK-COUNT-1: ( 1, 1, 1, 1, 1, 1, 1, 1, 1 )
+// Stats
+// CHECK: ( {{[0-9]+}}{{.?}}{{[0-9e-]+}}, {{[0-9]+}}{{.?}}{{[0-9e-]+}} )
 
 // TPP: func.func @entry(
 // TPP-SAME:  %[[ARG0:.+]]: memref<6x9xf32>,

--- a/test/Benchmarks/simple_copy.mlir
+++ b/test/Benchmarks/simple_copy.mlir
@@ -3,7 +3,7 @@
 // RUN: -drop-equivalent-buffer-results -finalizing-bufferize -canonicalize \
 // RUN: -convert-linalg-to-tpp -convert-tpp-to-xsmm \
 // RUN: -convert-xsmm-to-func | \
-// RUN: tpp-run -n 2 \
+// RUN: tpp-run -n 2000\
 // RUN:  -e entry -entry-point-result=void  \
 // RUN: -shared-libs=%llvmlirdir/libmlir_c_runner_utils%shlibext,%tpplibdir/libtpp_c_runner_utils%shlibext | \
 // RUN: FileCheck %s

--- a/tpp-rt/CMakeLists.txt
+++ b/tpp-rt/CMakeLists.txt
@@ -3,6 +3,7 @@ if (NOT TPP_INSIDE_IREE)
     SHARED
     XsmmRunnerUtils.cpp
     CheckRunnerUtils.cpp
+    PerfRunnerUtils.cpp
 
     LINK_LIBS PUBLIC
     xsmm
@@ -14,6 +15,7 @@ else()
     STATIC
     XsmmRunnerUtils.cpp
     CheckRunnerUtils.cpp
+    PerfRunnerUtils.cpp
   )
   target_link_libraries(tpp_c_runner_utils xsmm)
 endif()

--- a/tpp-rt/PerfRunnerUtils.cpp
+++ b/tpp-rt/PerfRunnerUtils.cpp
@@ -1,0 +1,89 @@
+//===- CRunnerUtils.cpp - Utils for MLIR execution ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities to measure performance (timers, statistics, etc).
+//
+//===----------------------------------------------------------------------===//
+
+#include "PerfRunnerUtils.h"
+#include <cstdlib>
+#include <time.h>
+
+namespace {
+/// Local class to keep the results and stats of each measurement
+class PerfResults {
+  double mean = 0.0;
+  double stdev = 0.0;
+  std::vector<double> timings;
+
+  void stats() {
+    auto size = timings.size();
+    // Mean
+    double sum = 0.0;
+    for (size_t i = 0; i < size; i++)
+      sum += timings[i];
+    mean = sum / size;
+    // Stdev
+    sum = 0.0;
+    for (size_t i = 0; i < size; i++) {
+      double delta = timings[i] - mean;
+      sum += delta * delta;
+    }
+    stdev = sqrt(sum / size);
+  }
+
+public:
+  void accumulate(double val) {
+    timings.push_back(val);
+  }
+
+  double getMean() {
+    if (mean == 0.0)
+      stats();
+    return mean;
+  }
+
+  double getStdev() {
+    if (stdev == 0.0)
+      stats();
+    return stdev;
+  }
+};
+
+/// Vector with all results
+/// Using memref/vector in MLIR is too much of a pain.
+std::vector<PerfResults> timerResults;
+} // namespace
+
+/// Returns the index of the result in the local vector that can be
+/// used as an ID to time, accumulate and get stats.
+int64_t _mlir_ciface_timer_alloc() {
+  timerResults.push_back({});
+  return timerResults.size() - 1;
+}
+
+double _mlir_ciface_timer_now() { return (double)clock() / CLOCKS_PER_SEC; }
+
+void _mlir_ciface_timer_accumulate(int64_t acc, double val) {
+  assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
+  auto& perfResults = timerResults[acc];
+  perfResults.accumulate(val);
+}
+
+double _mlir_ciface_timer_average(int64_t acc) {
+  assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
+  auto& perfResults = timerResults[acc];
+  return perfResults.getMean();
+}
+
+double _mlir_ciface_timer_deviation(int64_t acc) {
+  assert(acc >= 0 && (int64_t)timerResults.size() > acc && "Invalid timer ID");
+  auto& perfResults = timerResults[acc];
+  return perfResults.getStdev();
+}
+

--- a/tpp-rt/PerfRunnerUtils.h
+++ b/tpp-rt/PerfRunnerUtils.h
@@ -17,15 +17,14 @@
 
 extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_timer_alloc();
 
-extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_timer_now();
+extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_timer_start(int64_t);
 
-extern "C" MLIR_RUNNERUTILS_EXPORT void
-_mlir_ciface_timer_accumulate(int64_t, double);
+extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_timer_stop(int64_t);
 
-extern "C" MLIR_RUNNERUTILS_EXPORT double
-_mlir_ciface_timer_average(int64_t);
+extern "C" MLIR_RUNNERUTILS_EXPORT void _mlir_ciface_timer_accumulate(int64_t);
 
-extern "C" MLIR_RUNNERUTILS_EXPORT double
-_mlir_ciface_timer_deviation(int64_t);
+extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_timer_average(int64_t);
+
+extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_timer_deviation(int64_t);
 
 #endif // TPP_EXECUTIONENGINE_PERFRUNNERUTILS_H

--- a/tpp-rt/PerfRunnerUtils.h
+++ b/tpp-rt/PerfRunnerUtils.h
@@ -1,0 +1,31 @@
+//===- PerfRunnerUtils.h - Utils for debugging MLIR execution -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities to measure performance (timers, statistics, etc).
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_EXECUTIONENGINE_PERFRUNNERUTILS_H
+#define TPP_EXECUTIONENGINE_PERFRUNNERUTILS_H
+
+#include "mlir/ExecutionEngine/RunnerUtils.h"
+
+extern "C" MLIR_RUNNERUTILS_EXPORT int64_t _mlir_ciface_timer_alloc();
+
+extern "C" MLIR_RUNNERUTILS_EXPORT double _mlir_ciface_timer_now();
+
+extern "C" MLIR_RUNNERUTILS_EXPORT void
+_mlir_ciface_timer_accumulate(int64_t, double);
+
+extern "C" MLIR_RUNNERUTILS_EXPORT double
+_mlir_ciface_timer_average(int64_t);
+
+extern "C" MLIR_RUNNERUTILS_EXPORT double
+_mlir_ciface_timer_deviation(int64_t);
+
+#endif // TPP_EXECUTIONENGINE_PERFRUNNERUTILS_H

--- a/tpp-run/MLIRBench.cpp
+++ b/tpp-run/MLIRBench.cpp
@@ -196,10 +196,9 @@ Value MLIRBench::createTimerLoop(llvm::SmallVector<llvm::StringRef> &list,
 
 Value MLIRBench::getTimerStats(Value acc) {
   // Get stats (this is done once, but we can get values in separate)
-  ValueRange args{acc};
-  auto callMean = builder.create<func::CallOp>(unkLoc, timer.average, args);
+  auto callMean = builder.create<func::CallOp>(unkLoc, timer.average, ValueRange{acc});
   auto mean = callMean.getResult(0);
-  auto callDev = builder.create<func::CallOp>(unkLoc, timer.deviation, args);
+  auto callDev = builder.create<func::CallOp>(unkLoc, timer.deviation, ValueRange{acc});
   auto dev = callDev.getResult(0);
 
   // Create a vector<2xf64> so we can print

--- a/tpp-run/MLIRBench.h
+++ b/tpp-run/MLIRBench.h
@@ -65,8 +65,8 @@ class MLIRBench {
   void declareGlobalFunctions();
   struct {
     func::FuncOp alloc;
-    func::FuncOp now;
-    func::FuncOp accumulate;
+    func::FuncOp start;
+    func::FuncOp stop;
     func::FuncOp average;
     func::FuncOp deviation;
   } timer;


### PR DESCRIPTION
This commit enables benchmarking of generic kernels (with variable 2D tensor input variables and return vaule) by running it multiple times and using a runtime library to time, accumulate and calculate some basic mean+-dev statistics if the `-n` argument is greater than 1.

A few considerations:
 * The runtime is an implementation of what we expect will be the `perf` dialect. Once we have such a dialect, we should remove the perf logic from the benchmark and just use that dialect.
 * The restriction of 2D inputs are due to the printing via vector extract. It should be reasonably easy to extend it to xD memrefs later.
 * The API is still a bit clumsy. I don't want to change too many things at the same time. So, once we consolidate on a working mechanism (`perf` and `check` dialects, xD memrefs, etc), we can revisit the API.

Fixes #74

@hfp, this is the starting point of a generic benchmark runner for MLIR.