### PR TITLE
Enable BF16 tests on AVX2 machines

### DIFF
--- a/test/BF16/lit.local.cfg
+++ b/test/BF16/lit.local.cfg
@@ -20,5 +20,5 @@ def has_support(feature):
     return True
 
 # AVX512 and SVE should have BF16 support
-if not has_support('avx512') and not has_support('sve'):
+if not has_support('avx512') and not has_support('avx2') and not has_support('sve'):
     config.unsupported = True


### PR DESCRIPTION
Now that libxsmm supports BF16 on AVX2 machines, we can enable those tests on a wider range of extensions.